### PR TITLE
fix(prettier): Don't alter text buffer if file is already pretty

### DIFF
--- a/dist/executePrettier.js
+++ b/dist/executePrettier.js
@@ -51,7 +51,8 @@ var executePrettierOnBufferRange = function executePrettierOnBufferRange(editor,
   var textToTransform = editor.getTextInBufferRange(bufferRange);
   var transformed = executePrettier(editor, textToTransform);
 
-  if (!transformed) return;
+  var isTextUnchanged = transformed === textToTransform;
+  if (!transformed || isTextUnchanged) return;
 
   editor.setTextInBufferRange(bufferRange, transformed);
   editor.setCursorScreenPosition(cursorPositionPriorToFormat);

--- a/src/executePrettier.js
+++ b/src/executePrettier.js
@@ -47,7 +47,8 @@ const executePrettierOnBufferRange = (editor: TextEditor, bufferRange: Range) =>
   const textToTransform = editor.getTextInBufferRange(bufferRange);
   const transformed = executePrettier(editor, textToTransform);
 
-  if (!transformed) return;
+  const isTextUnchanged = transformed === textToTransform;
+  if (!transformed || isTextUnchanged) return;
 
   editor.setTextInBufferRange(bufferRange, transformed);
   editor.setCursorScreenPosition(cursorPositionPriorToFormat);

--- a/src/executePrettier.test.js
+++ b/src/executePrettier.test.js
@@ -77,6 +77,24 @@ describe('executePrettierOnBufferRange()', () => {
     });
   });
 
+  describe('when text in buffer range is already pretty', () => {
+    beforeEach(() => {
+      prettier.format.mockImplementation(() => 'untransformed text');
+    });
+
+    test("does not change the text in the editor's buffer range", () => {
+      executePrettierOnBufferRange(editor, bufferRangeFixture);
+
+      expect(editor.setTextInBufferRange).not.toHaveBeenCalled();
+    });
+
+    test("does not change the editor's cursor position", () => {
+      executePrettierOnBufferRange(editor, bufferRangeFixture);
+
+      expect(editor.setCursorScreenPosition).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when prettier throws an error', () => {
     beforeEach(() => {
       prettier.format.mockImplementation(() => {


### PR DESCRIPTION
This PR brings two improvements, it:
- removes unnecessary glitches that happen when the content of the editor is overwritten
- preserves the history, since it removes unnecessary text buffer changes