### PR TITLE
feat(error): Cleanup error notification

### DIFF
--- a/dist/executePrettier.js
+++ b/dist/executePrettier.js
@@ -19,10 +19,11 @@ var _require2 = require('./helpers'),
 var EMBEDDED_JS_REGEX = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi;
 
 var displayError = function displayError(error) {
-  var message = 'prettier-atom: ' + error.toString();
-  var detail = error.stack.toString();
-
-  atom.notifications.addError(message, { detail: detail, dismissable: true });
+  atom.notifications.addError('prettier-atom failed!', {
+    detail: error,
+    stack: error.stack,
+    dismissable: true
+  });
 };
 
 var handleError = function handleError(error) {

--- a/src/executePrettier.js
+++ b/src/executePrettier.js
@@ -15,10 +15,11 @@ const {
 const EMBEDDED_JS_REGEX = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi;
 
 const displayError = (error) => {
-  const message = `prettier-atom: ${error.toString()}`;
-  const detail = error.stack.toString();
-
-  atom.notifications.addError(message, { detail, dismissable: true });
+  atom.notifications.addError('prettier-atom failed!', {
+    detail: error,
+    stack: error.stack,
+    dismissable: true,
+  });
 };
 
 const handleError = (error) => {


### PR DESCRIPTION
This PR shortens the error notification while keeping the option to show the whole stack trace.

**Proposed:**
<img width="486" alt="bildschirmfoto 2017-04-02 um 11 33 40" src="https://cloud.githubusercontent.com/assets/13285808/24586065/357b36c0-1799-11e7-98cf-810c23ef3aab.png">
<img width="493" alt="bildschirmfoto 2017-04-02 um 11 33 52" src="https://cloud.githubusercontent.com/assets/13285808/24586066/357c0000-1799-11e7-8f04-6b0d62c678b0.png">


**master:**
<img width="479" alt="bildschirmfoto 2017-04-02 um 11 38 37" src="https://cloud.githubusercontent.com/assets/13285808/24586067/357c3e44-1799-11e7-8ca6-32f0e4645cb5.png">

Fixes #49 