### PR TITLE
Enable context menu entry for JSX files

### DIFF
--- a/menus/prettier-js.json
+++ b/menus/prettier-js.json
@@ -2,7 +2,7 @@
   "context-menu": {
     "atom-text-editor[data-grammar='source js'], atom-text-editor[data-grammar='source js jsx']": [
       {
-        "label": "Format With prettier",
+        "label": "Format With Prettier",
         "command": "prettier:format"
       }
     ]
@@ -12,7 +12,7 @@
       "label": "Packages",
       "submenu": [
         {
-          "label": "prettier",
+          "label": "Prettier",
           "submenu": [
             {
               "label": "Format",

--- a/menus/prettier-js.json
+++ b/menus/prettier-js.json
@@ -1,6 +1,6 @@
 {
   "context-menu": {
-    "atom-text-editor[data-grammar='source js']": [
+    "atom-text-editor[data-grammar='source js'], atom-text-editor[data-grammar='source js jsx']": [
       {
         "label": "Format With prettier",
         "command": "prettier:format"


### PR DESCRIPTION
This time, with commitizen.

Context menus didn't include the `Format` action for files that use `Babel` or `JavaScript with JSX` for syntax highlight (from the `language-babel` package).