### PR TITLE
docs(issue-template): add message about prettier and prettier-eslint repos

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,11 @@
-<!-- Describe your issue here with as many details as possible -->
+<!--
+Before you post an issue, please ensure that your issue is not with the
+[prettier](https://github.com/prettier/prettier) or
+[prettier-eslint](https://github.com/prettier/prettier-eslint) packages. This is just the
+atom plugin that calls these packages under the hood.
+
+Describe your issue here with as many details as possible
+-->
 
 <!--
 Paste the output of the `Prettier: Debug` command below.


### PR DESCRIPTION
We are getting many issues that actually should have been posted on prettier or prettier-eslint.
Hopefully this should head some of those issues off before they get created.