### PR TITLE
Toggle command for "Format on Save" option

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,6 +11,7 @@ plugins:
 
 globals:
   atom: true
+  document: false
 
 env:
   node: true

--- a/decls/index.js
+++ b/decls/index.js
@@ -42,6 +42,7 @@ declare var atom: {
   },
   config: {
     get: (key: string) => any,
+    set: (key: string) => any,
   },
   notifications: {
     addError: (message: string, options?: { detail?: string, dismissable?: boolean }) => void,

--- a/decls/index.js
+++ b/decls/index.js
@@ -32,6 +32,7 @@ declare type TextEditor = {
     }) => void,
   ) => void,
 };
+declare type Atom$Disposable = any;
 declare type Atom$View = any;
 declare type Atom$Workspace = any;
 declare type Atom$Command = { name: string, displayName: string };
@@ -46,6 +47,10 @@ declare var atom: {
   },
   notifications: {
     addError: (message: string, options?: { detail?: string, dismissable?: boolean }) => void,
+    addInfo: (message: string, options?: { detail?: string, dismissable?: boolean }) => void,
+  },
+  tooltips: {
+    add: (target: HTMLElement, options?: { title?: string }) => Atom$Disposable
   },
   views: {
     getView: Atom$Workspace => Atom$View,

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -106,6 +106,10 @@ var getConfigOption = function getConfigOption(key) {
   return atom.config.get('prettier-atom.' + key);
 };
 
+var setConfigOption = function setConfigOption(key, value) {
+  return atom.config.set('prettier-atom.' + key, value);
+};
+
 var shouldDisplayErrors = function shouldDisplayErrors() {
   return !getConfigOption('silenceErrors');
 };
@@ -202,6 +206,7 @@ var getDebugInfo = function getDebugInfo() {
 
 module.exports = {
   getConfigOption: getConfigOption,
+  setConfigOption: setConfigOption,
   shouldDisplayErrors: shouldDisplayErrors,
   getPrettierOption: getPrettierOption,
   getPrettierEslintOption: getPrettierEslintOption,

--- a/dist/main.js
+++ b/dist/main.js
@@ -13,6 +13,7 @@ var format = null;
 var formatOnSave = null;
 var warnAboutLinterEslintFixOnSave = null;
 var displayDebugInfo = null;
+var toggleFormatOnSave = null;
 var subscriptions = null;
 
 // HACK: lazy load most of the code we need for performance
@@ -49,12 +50,22 @@ var lazyDisplayDebugInfo = function lazyDisplayDebugInfo() {
   displayDebugInfo();
 };
 
+var lazyToggleFormatOnSave = function lazyToggleFormatOnSave() {
+  if (!toggleFormatOnSave) {
+    // eslint-disable-next-line global-require
+    toggleFormatOnSave = require('./toggleFormatOnSave');
+  }
+  toggleFormatOnSave();
+};
+
 // public API
 var activate = function activate() {
   subscriptions = new CompositeDisposable();
 
   subscriptions.add(atom.commands.add('atom-workspace', 'prettier:format', lazyFormat));
   subscriptions.add(atom.commands.add('atom-workspace', 'prettier:debug', lazyDisplayDebugInfo));
+  subscriptions.add(atom.commands.add('atom-workspace', 'prettier:toggle-format-on-save', lazyToggleFormatOnSave));
+
   subscriptions.add(atom.workspace.observeTextEditors(function (editor) {
     return subscriptions.add(editor.getBuffer().onWillSave(function () {
       return lazyFormatOnSave(editor);

--- a/dist/main.js
+++ b/dist/main.js
@@ -6,6 +6,10 @@ var config = require('./config-schema.json');
 var _require = require('atom'),
     CompositeDisposable = _require.CompositeDisposable;
 
+var _require2 = require('./statusTile'),
+    createStatusTile = _require2.createStatusTile,
+    updateStatusTile = _require2.updateStatusTile;
+
 // local helpers
 
 
@@ -15,6 +19,8 @@ var warnAboutLinterEslintFixOnSave = null;
 var displayDebugInfo = null;
 var toggleFormatOnSave = null;
 var subscriptions = null;
+var statusBarTile = null;
+var tileElement = null;
 
 // HACK: lazy load most of the code we need for performance
 var lazyFormat = function lazyFormat() {
@@ -86,11 +92,28 @@ var activate = function activate() {
 
 var deactivate = function deactivate() {
   subscriptions.dispose();
+  if (statusBarTile) {
+    statusBarTile.destroy();
+  }
+};
+
+var consumeStatusBar = function consumeStatusBar(statusBar) {
+  tileElement = createStatusTile();
+  statusBarTile = statusBar.addLeftTile({
+    item: tileElement,
+    priority: 1000
+  });
+  updateStatusTile(subscriptions, tileElement);
+
+  subscriptions.add(atom.config.observe('prettier-atom.formatOnSaveOptions.enabled', function () {
+    return updateStatusTile(subscriptions, tileElement);
+  }));
 };
 
 module.exports = {
   activate: activate,
   deactivate: deactivate,
   config: config,
-  subscriptions: subscriptions
+  subscriptions: subscriptions,
+  consumeStatusBar: consumeStatusBar
 };

--- a/dist/main.js
+++ b/dist/main.js
@@ -8,7 +8,8 @@ var _require = require('atom'),
 
 var _require2 = require('./statusTile'),
     createStatusTile = _require2.createStatusTile,
-    updateStatusTile = _require2.updateStatusTile;
+    updateStatusTile = _require2.updateStatusTile,
+    disposeTooltip = _require2.disposeTooltip;
 
 // local helpers
 
@@ -92,6 +93,7 @@ var activate = function activate() {
 
 var deactivate = function deactivate() {
   subscriptions.dispose();
+  disposeTooltip();
   if (statusBarTile) {
     statusBarTile.destroy();
   }

--- a/dist/statusTile.js
+++ b/dist/statusTile.js
@@ -29,6 +29,8 @@ var updateStatusTile = function updateStatusTile(disposable, element) {
   }
   tooltip = atom.tooltips.add(element, { title: 'Format on Save: ' + getFormatOnSaveStatus() });
   disposable.add(tooltip);
+
+  return tooltip;
 };
 
 module.exports = {

--- a/dist/statusTile.js
+++ b/dist/statusTile.js
@@ -20,13 +20,18 @@ var createStatusTile = function createStatusTile() {
   return element;
 };
 
+var disposeTooltip = function disposeTooltip() {
+  if (tooltip) {
+    tooltip.dispose();
+  }
+};
+
 var updateStatusTile = function updateStatusTile(disposable, element) {
   // eslint-disable-next-line no-param-reassign
   element.dataset.formatOnSave = getFormatOnSaveStatus();
 
-  if (tooltip) {
-    tooltip.dispose();
-  }
+  disposeTooltip();
+
   tooltip = atom.tooltips.add(element, { title: 'Format on Save: ' + getFormatOnSaveStatus() });
   disposable.add(tooltip);
 
@@ -35,5 +40,6 @@ var updateStatusTile = function updateStatusTile(disposable, element) {
 
 module.exports = {
   createStatusTile: createStatusTile,
-  updateStatusTile: updateStatusTile
+  updateStatusTile: updateStatusTile,
+  disposeTooltip: disposeTooltip
 };

--- a/dist/statusTile.js
+++ b/dist/statusTile.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var _require = require('./helpers'),
+    getConfigOption = _require.getConfigOption;
+
+var tooltip = null;
+
+var getFormatOnSaveStatus = function getFormatOnSaveStatus() {
+  return getConfigOption('formatOnSaveOptions.enabled') ? 'enabled' : 'disabled';
+};
+
+var createStatusTile = function createStatusTile() {
+  var element = document.createElement('div');
+  element.classList.add('prettier-atom-status-tile');
+  element.classList.add('inline-block');
+  element.dataset.formatOnSave = getFormatOnSaveStatus();
+
+  element.appendChild(document.createTextNode('Prettier'));
+
+  return element;
+};
+
+var updateStatusTile = function updateStatusTile(disposable, element) {
+  // eslint-disable-next-line no-param-reassign
+  element.dataset.formatOnSave = getFormatOnSaveStatus();
+
+  if (tooltip) {
+    tooltip.dispose();
+  }
+  tooltip = atom.tooltips.add(element, { title: 'Format on Save: ' + getFormatOnSaveStatus() });
+  disposable.add(tooltip);
+};
+
+module.exports = {
+  createStatusTile: createStatusTile,
+  updateStatusTile: updateStatusTile
+};

--- a/dist/toggleFormatOnSave.js
+++ b/dist/toggleFormatOnSave.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var _require = require('./helpers'),
+    getConfigOption = _require.getConfigOption,
+    setConfigOption = _require.setConfigOption;
+
+var toggleFormatOnSave = function toggleFormatOnSave() {
+  var key = 'formatOnSaveOptions.enabled';
+  setConfigOption(key, !getConfigOption(key));
+};
+
+module.exports = toggleFormatOnSave;

--- a/menus/prettier-js.json
+++ b/menus/prettier-js.json
@@ -21,6 +21,10 @@
             {
               "label": "Debug",
               "command": "prettier:debug"
+            },
+            {
+              "label": "Toggle Format on Save",
+              "command": "prettier:toggle-format-on-save"
             }
           ]
         }

--- a/package.json
+++ b/package.json
@@ -77,5 +77,12 @@
       "src"
     ],
     "testEnvironment": "node"
+  },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^1.0.0": "consumeStatusBar"
+      }
+    }
   }
 }

--- a/src/displayDebugInfo.js
+++ b/src/displayDebugInfo.js
@@ -1,3 +1,4 @@
+// @flow
 const { getDebugInfo } = require('./helpers');
 
 const displayDebugInfo = () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -82,6 +82,8 @@ const getDepPath = (dep: string) => path.join(__dirname, '../node_modules', dep)
 // public helpers
 const getConfigOption = (key: string) => atom.config.get(`prettier-atom.${key}`);
 
+const setConfigOption = (key: string, value: any) => atom.config.set(`prettier-atom.${key}`, value);
+
 const shouldDisplayErrors = () => !getConfigOption('silenceErrors');
 
 const getPrettierOption = (key: string) => getConfigOption(`prettierOptions.${key}`);
@@ -153,6 +155,7 @@ const getDebugInfo = () => ({
 
 module.exports = {
   getConfigOption,
+  setConfigOption,
   shouldDisplayErrors,
   getPrettierOption,
   getPrettierEslintOption,

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,11 @@
 const config = require('./config-schema.json');
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 const { CompositeDisposable } = require('atom');
-const { createStatusTile, updateStatusTile } = require('./statusTile');
+const {
+  createStatusTile,
+  updateStatusTile,
+  disposeTooltip,
+} = require('./statusTile');
 
 // local helpers
 let format = null;
@@ -85,6 +89,7 @@ const activate = () => {
 
 const deactivate = () => {
   subscriptions.dispose();
+  disposeTooltip();
   if (statusBarTile) {
     statusBarTile.destroy();
   }

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ let format = null;
 let formatOnSave = null;
 let warnAboutLinterEslintFixOnSave = null;
 let displayDebugInfo = null;
+let toggleFormatOnSave = null;
 let subscriptions = null;
 
 // HACK: lazy load most of the code we need for performance
@@ -43,12 +44,24 @@ const lazyDisplayDebugInfo = () => {
   displayDebugInfo();
 };
 
+const lazyToggleFormatOnSave = () => {
+  if (!toggleFormatOnSave) {
+    // eslint-disable-next-line global-require
+    toggleFormatOnSave = require('./toggleFormatOnSave');
+  }
+  toggleFormatOnSave();
+};
+
 // public API
 const activate = () => {
   subscriptions = new CompositeDisposable();
 
   subscriptions.add(atom.commands.add('atom-workspace', 'prettier:format', lazyFormat));
   subscriptions.add(atom.commands.add('atom-workspace', 'prettier:debug', lazyDisplayDebugInfo));
+  subscriptions.add(
+    atom.commands.add('atom-workspace', 'prettier:toggle-format-on-save', lazyToggleFormatOnSave),
+  );
+
   subscriptions.add(
     atom.workspace.observeTextEditors(editor =>
       subscriptions.add(editor.getBuffer().onWillSave(() => lazyFormatOnSave(editor))),

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 const config = require('./config-schema.json');
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 const { CompositeDisposable } = require('atom');
+const { createStatusTile, updateStatusTile } = require('./statusTile');
 
 // local helpers
 let format = null;
@@ -9,6 +10,8 @@ let warnAboutLinterEslintFixOnSave = null;
 let displayDebugInfo = null;
 let toggleFormatOnSave = null;
 let subscriptions = null;
+let statusBarTile = null;
+let tileElement = null;
 
 // HACK: lazy load most of the code we need for performance
 const lazyFormat = () => {
@@ -82,6 +85,25 @@ const activate = () => {
 
 const deactivate = () => {
   subscriptions.dispose();
+  if (statusBarTile) {
+    statusBarTile.destroy();
+  }
+};
+
+const consumeStatusBar = (statusBar) => {
+  tileElement = createStatusTile();
+  statusBarTile = statusBar.addLeftTile({
+    item: tileElement,
+    priority: 1000,
+  });
+  updateStatusTile(subscriptions, tileElement);
+
+  subscriptions.add(
+    atom.config.observe(
+      'prettier-atom.formatOnSaveOptions.enabled',
+      () => updateStatusTile(subscriptions, tileElement),
+    ),
+  );
 };
 
 module.exports = {
@@ -89,4 +111,5 @@ module.exports = {
   deactivate,
   config,
   subscriptions,
+  consumeStatusBar,
 };

--- a/src/statusTile.js
+++ b/src/statusTile.js
@@ -25,6 +25,8 @@ const updateStatusTile = (disposable: Atom$Disposable, element: HTMLElement) => 
   }
   tooltip = atom.tooltips.add(element, { title: `Format on Save: ${getFormatOnSaveStatus()}` });
   disposable.add(tooltip);
+
+  return tooltip;
 };
 
 module.exports = {

--- a/src/statusTile.js
+++ b/src/statusTile.js
@@ -16,13 +16,18 @@ const createStatusTile = () => {
   return element;
 };
 
+const disposeTooltip = () => {
+  if (tooltip) {
+    tooltip.dispose();
+  }
+};
+
 const updateStatusTile = (disposable: Atom$Disposable, element: HTMLElement) => {
   // eslint-disable-next-line no-param-reassign
   element.dataset.formatOnSave = getFormatOnSaveStatus();
 
-  if (tooltip) {
-    tooltip.dispose();
-  }
+  disposeTooltip();
+
   tooltip = atom.tooltips.add(element, { title: `Format on Save: ${getFormatOnSaveStatus()}` });
   disposable.add(tooltip);
 
@@ -32,4 +37,5 @@ const updateStatusTile = (disposable: Atom$Disposable, element: HTMLElement) => 
 module.exports = {
   createStatusTile,
   updateStatusTile,
+  disposeTooltip,
 };

--- a/src/statusTile.js
+++ b/src/statusTile.js
@@ -1,0 +1,33 @@
+// @flow
+const { getConfigOption } = require('./helpers');
+
+let tooltip: Atom$Disposable = null;
+
+const getFormatOnSaveStatus = () => getConfigOption('formatOnSaveOptions.enabled') ? 'enabled' : 'disabled';
+
+const createStatusTile = () => {
+  const element = document.createElement('div');
+  element.classList.add('prettier-atom-status-tile');
+  element.classList.add('inline-block');
+  element.dataset.formatOnSave = getFormatOnSaveStatus();
+
+  element.appendChild(document.createTextNode('Prettier'));
+
+  return element;
+};
+
+const updateStatusTile = (disposable: Atom$Disposable, element: HTMLElement) => {
+  // eslint-disable-next-line no-param-reassign
+  element.dataset.formatOnSave = getFormatOnSaveStatus();
+
+  if (tooltip) {
+    tooltip.dispose();
+  }
+  tooltip = atom.tooltips.add(element, { title: `Format on Save: ${getFormatOnSaveStatus()}` });
+  disposable.add(tooltip);
+};
+
+module.exports = {
+  createStatusTile,
+  updateStatusTile,
+};

--- a/src/statusTile.test.js
+++ b/src/statusTile.test.js
@@ -1,0 +1,36 @@
+// @flow
+const { createStatusTile, updateStatusTile } = require('./statusTile');
+
+test('it creates a div with a proper class name, a "Prettier" text node and a tooltip', () => {
+  atom = {
+    config: { get: jest.fn(() => true) },
+    tooltips: { add: () => ({ prop: '...' }) },
+  };
+
+  const classes = [];
+  global.document = {
+    createElement: jest.fn(() => ({
+      classList: {
+        add: jest.fn(arg => classes.push(arg)),
+      },
+      dataset: {},
+      appendChild: jest.fn(),
+    })),
+    createTextNode: jest.fn(arg => arg),
+  };
+
+  const div = createStatusTile();
+  expect(div).toBeDefined();
+  expect(div.dataset.formatOnSave).toBe('enabled');
+  expect(classes.includes('prettier-atom-status-tile')).toBe(true);
+  expect(document.createTextNode).toHaveBeenCalledWith('Prettier');
+
+  const disposable = { add: jest.fn() };
+  const tooltip = updateStatusTile(disposable, div);
+  expect(tooltip.prop).toBe('...');
+  expect(disposable.add).toHaveBeenCalled();
+
+  tooltip.dispose = jest.fn();
+  updateStatusTile(disposable, div);
+  expect(tooltip.dispose).toHaveBeenCalled();
+});

--- a/src/toggleFormatOnSave.js
+++ b/src/toggleFormatOnSave.js
@@ -1,9 +1,10 @@
 // @flow
 const { getConfigOption, setConfigOption } = require('./helpers');
 
+const FORMAT_ON_SAVE = 'formatOnSaveOptions.enabled';
+
 const toggleFormatOnSave = () => {
-  const key = 'formatOnSaveOptions.enabled';
-  setConfigOption(key, !getConfigOption(key));
+  setConfigOption(FORMAT_ON_SAVE, !getConfigOption(FORMAT_ON_SAVE));
 };
 
 module.exports = toggleFormatOnSave;

--- a/src/toggleFormatOnSave.js
+++ b/src/toggleFormatOnSave.js
@@ -1,0 +1,8 @@
+const { getConfigOption, setConfigOption } = require('./helpers');
+
+const toggleFormatOnSave = () => {
+  const key = 'formatOnSaveOptions.enabled';
+  setConfigOption(key, !getConfigOption(key));
+};
+
+module.exports = toggleFormatOnSave;

--- a/src/toggleFormatOnSave.js
+++ b/src/toggleFormatOnSave.js
@@ -1,3 +1,4 @@
+// @flow
 const { getConfigOption, setConfigOption } = require('./helpers');
 
 const toggleFormatOnSave = () => {

--- a/src/toggleFormatOnSave.test.js
+++ b/src/toggleFormatOnSave.test.js
@@ -1,0 +1,18 @@
+// @flow
+const toggleFormatOnSave = require('./toggleFormatOnSave');
+const { getConfigOption } = require('./helpers');
+
+test('it toggles the state of prettier-atom\'s option formatOnSaveOptions.enabled', () => {
+  let enabled = false;
+  atom = {
+    config: {
+      get: jest.fn(() => enabled),
+      set: jest.fn((key, value) => (enabled = value)),
+    },
+  };
+
+  toggleFormatOnSave();
+  expect(getConfigOption('...')).toBe(true);
+  toggleFormatOnSave();
+  expect(getConfigOption('...')).toBe(false);
+});

--- a/src/toggleFormatOnSave.test.js
+++ b/src/toggleFormatOnSave.test.js
@@ -1,18 +1,28 @@
 // @flow
 const toggleFormatOnSave = require('./toggleFormatOnSave');
-const { getConfigOption } = require('./helpers');
 
-test('it toggles the state of prettier-atom\'s option formatOnSaveOptions.enabled', () => {
-  let enabled = false;
+test('it sets formatOnSaveOptions.enabled to false if it was true', () => {
   atom = {
     config: {
-      get: jest.fn(() => enabled),
-      set: jest.fn((key, value) => (enabled = value)),
+      get: jest.fn(() => true),
+      set: jest.fn(),
     },
   };
 
   toggleFormatOnSave();
-  expect(getConfigOption('...')).toBe(true);
+
+  expect(atom.config.set).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.enabled', false);
+});
+
+test('it sets formatOnSaveOptions.enabled to true if it was false', () => {
+  atom = {
+    config: {
+      get: jest.fn(() => false),
+      set: jest.fn(),
+    },
+  };
+
   toggleFormatOnSave();
-  expect(getConfigOption('...')).toBe(false);
+
+  expect(atom.config.set).toHaveBeenCalledWith('prettier-atom.formatOnSaveOptions.enabled', true);
 });

--- a/styles/statusTile.css
+++ b/styles/statusTile.css
@@ -1,0 +1,7 @@
+div[data-format-on-save="enabled"] {
+  color: #8BC34A;
+}
+
+div[data-format-on-save="enabled"]::after {
+  content: " ✓";
+}


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier-atom/issues/117.

The new command is defined as `prettier:toggle-format-on-save`.

I also wanted to add a visual indicator for the command, because it's not practical when you don't know if the option is already enabled or not.

I tried to make something in the status bar with Prettier's logo, but it looked terrible with small dimensions and it didn't fit with the other tiles.
I ended up just adding a "Prettier" label:

<details>

**Enabled**
![](https://i.imgur.com/XCCpwZf.png)

**Disabled**
![](https://i.imgur.com/SwQ4m4l.png)

</details>