### PR TITLE
feat(eslint-fallbacks): fallback to user's prettier settings if cannot be inferred from eslint confi

### DIFF
--- a/dist/config-schema.json
+++ b/dist/config-schema.json
@@ -8,7 +8,7 @@
   },
   "useEslint": {
     "title": "ESlint Integration",
-    "description": "Use [prettier-eslint](https://github.com/prettier/prettier-eslint). If you enable *Format on Save*, we recommend disabling ESlint's auto-fix to prevent fixing your code twice.<br /><br />**Note:** This will override any options you choose in the *Prettier Options* section.",
+    "description": "Use [prettier-eslint](https://github.com/prettier/prettier-eslint) to infer your prettier settings based on your eslint config. If we cannot infer a prettier setting from your eslint config (or if there is no eslint config in the current project), we will fallback to using your settings in the *Prettier Options* section.<br /><br />**Note:** If you enable *Format on Save*, we recommend disabling ESlint's auto-fix to prevent fixing your code twice.",
     "type": "boolean",
     "default": false,
     "order": 2

--- a/dist/executePrettier.js
+++ b/dist/executePrettier.js
@@ -33,17 +33,19 @@ var handleError = function handleError(error) {
 
 var executePrettier = function executePrettier(editor, text) {
   try {
+    var prettierOptions = getPrettierOptions(editor);
+
     if (shouldUseEslint()) {
       return allowUnsafeNewFunction(function () {
         return prettierEslint(_extends({}, getPrettierEslintOptions(), {
           text: text,
-          filePath: getCurrentFilePath(editor)
+          filePath: getCurrentFilePath(editor),
+          fallbackPrettierOptions: prettierOptions
         }));
       });
     }
 
     var prettier = getPrettier(getCurrentFilePath(editor));
-    var prettierOptions = getPrettierOptions(editor);
 
     return prettier.format(text, prettierOptions);
   } catch (error) {

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -8,7 +8,7 @@
   },
   "useEslint": {
     "title": "ESlint Integration",
-    "description": "Use [prettier-eslint](https://github.com/prettier/prettier-eslint). If you enable *Format on Save*, we recommend disabling ESlint's auto-fix to prevent fixing your code twice.<br /><br />**Note:** This will override any options you choose in the *Prettier Options* section.",
+    "description": "Use [prettier-eslint](https://github.com/prettier/prettier-eslint) to infer your prettier settings based on your eslint config. If we cannot infer a prettier setting from your eslint config (or if there is no eslint config in the current project), we will fallback to using your settings in the *Prettier Options* section.<br /><br />**Note:** If you enable *Format on Save*, we recommend disabling ESlint's auto-fix to prevent fixing your code twice.",
     "type": "boolean",
     "default": false,
     "order": 2

--- a/src/executePrettier.js
+++ b/src/executePrettier.js
@@ -29,18 +29,20 @@ const handleError = (error) => {
 
 const executePrettier = (editor, text) => {
   try {
+    const prettierOptions = getPrettierOptions(editor);
+
     if (shouldUseEslint()) {
       return allowUnsafeNewFunction(() =>
         prettierEslint({
           ...getPrettierEslintOptions(),
           text,
           filePath: getCurrentFilePath(editor),
+          fallbackPrettierOptions: prettierOptions,
         }),
       );
     }
 
     const prettier = getPrettier(getCurrentFilePath(editor));
-    const prettierOptions = getPrettierOptions(editor);
 
     return prettier.format(text, prettierOptions);
   } catch (error) {

--- a/src/executePrettier.test.js
+++ b/src/executePrettier.test.js
@@ -55,27 +55,23 @@ describe('executePrettierOnBufferRange()', () => {
     // $FlowFixMe
     helpers.shouldUseEslint.mockImplementation(() => true);
     // $FlowFixMe
-    helpers.getCurrentFilePath.mockImplementation(() => 'foo.js');
-
-    executePrettierOnBufferRange(editor, bufferRangeFixture);
-
-    expect(prettierEslint).toHaveBeenCalledWith({ filePath: 'foo.js', text: 'untransformed text' });
-  });
-
-  test('passes prettierLast option to prettier-eslint', () => {
-    // $FlowFixMe
     helpers.shouldUseEslint.mockImplementation(() => true);
     // $FlowFixMe
-    helpers.getCurrentFilePath.mockImplementation(() => 'foo.js');
-    // $FlowFixMe
     helpers.getPrettierEslintOptions.mockImplementation(() => ({ prettierLast: true }));
+    // $FlowFixMe
+    helpers.getPrettierOptions.mockImplementation(() => ({ semi: true }));
+    // $FlowFixMe
+    helpers.getCurrentFilePath.mockImplementation(() => 'foo.js');
 
     executePrettierOnBufferRange(editor, bufferRangeFixture);
 
     expect(prettierEslint).toHaveBeenCalledWith({
-      prettierLast: true,
       filePath: 'foo.js',
       text: 'untransformed text',
+      prettierLast: true,
+      fallbackPrettierOptions: {
+        semi: true,
+      },
     });
   });
 


### PR DESCRIPTION
Previously, if we couldn't infer a prettier setting from a user's eslint config, we fell back to
default prettier settings. Now, we take advantage of a new prettier-eslint feature that let's us
provide fallback options to use instead of the prettier defaults. This means that if you don't have
a semicolons rule in your eslint config, we will use the semicolon rule from your prettier-atom
settings.