### PR TITLE
fix(debugCommand): Provide package's absolute path to read package.json

### DIFF
--- a/dist/displayDebugInfo/index.js
+++ b/dist/displayDebugInfo/index.js
@@ -13,7 +13,7 @@ var getDepPath = function getDepPath(dep) {
 };
 
 var getDebugInfo = function getDebugInfo() {
-  return ('\nAtom version: ' + getAtomVersion() + '\nprettier-atom version: ' + readPkg.sync().version + '\nprettier version: ' + readPkg.sync(getDepPath('prettier')).version + '\nprettier-eslint version: ' + readPkg.sync(getDepPath('prettier-eslint')).version + '\nprettier-atom configuration: ' + JSON.stringify(getPrettierAtomConfig(), null, 2) + '\n').trim();
+  return ('\nAtom version: ' + getAtomVersion() + '\nprettier-atom version: ' + readPkg.sync(path.join(__dirname, '..', '..')).version + '\nprettier version: ' + readPkg.sync(getDepPath('prettier')).version + '\nprettier-eslint version: ' + readPkg.sync(getDepPath('prettier-eslint')).version + '\nprettier-atom configuration: ' + JSON.stringify(getPrettierAtomConfig(), null, 2) + '\n').trim();
 };
 
 var displayDebugInfo = function displayDebugInfo() {

--- a/src/displayDebugInfo/index.js
+++ b/src/displayDebugInfo/index.js
@@ -8,7 +8,7 @@ const getDepPath = (dep: string) => path.join(__dirname, '..', '..', 'node_modul
 const getDebugInfo = () =>
   `
 Atom version: ${getAtomVersion()}
-prettier-atom version: ${readPkg.sync().version}
+prettier-atom version: ${readPkg.sync(path.join(__dirname, '..', '..')).version}
 prettier version: ${readPkg.sync(getDepPath('prettier')).version}
 prettier-eslint version: ${readPkg.sync(getDepPath('prettier-eslint')).version}
 prettier-atom configuration: ${JSON.stringify(getPrettierAtomConfig(), null, 2)}


### PR DESCRIPTION
Providing a relative path would mean depending on current working directory which could change on
different environments. This ensures we target the correct directory.

Fixes #156