### PR TITLE
feat(parsers): add typescript and CSS support

### DIFF
--- a/dist/atomInterface/index.js
+++ b/dist/atomInterface/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 // constants
 var LINTER_LINT_COMMAND = 'linter:lint';
 
@@ -47,8 +49,20 @@ var shouldRespectEslintignore = function shouldRespectEslintignore() {
   return getConfigOption('formatOnSaveOptions.respectEslintignore');
 };
 
-var getScopes = function getScopes() {
-  return getConfigOption('formatOnSaveOptions.scopes');
+var getJavascriptScopes = function getJavascriptScopes() {
+  return getConfigOption('formatOnSaveOptions.javascriptScopes');
+};
+
+var getTypescriptScopes = function getTypescriptScopes() {
+  return getConfigOption('formatOnSaveOptions.typescriptScopes');
+};
+
+var getCssScopes = function getCssScopes() {
+  return getConfigOption('formatOnSaveOptions.cssScopes');
+};
+
+var getAllScopes = function getAllScopes() {
+  return [].concat(_toConsumableArray(getJavascriptScopes()), _toConsumableArray(getTypescriptScopes()), _toConsumableArray(getCssScopes()));
 };
 
 var getWhitelistedGlobs = function getWhitelistedGlobs() {
@@ -114,7 +128,10 @@ module.exports = {
   getPrettierAtomConfig: getPrettierAtomConfig,
   getPrettierEslintOptions: getPrettierEslintOptions,
   getPrettierOptions: getPrettierOptions,
-  getScopes: getScopes,
+  getJavascriptScopes: getJavascriptScopes,
+  getTypescriptScopes: getTypescriptScopes,
+  getCssScopes: getCssScopes,
+  getAllScopes: getAllScopes,
   getWhitelistedGlobs: getWhitelistedGlobs,
   isDisabledIfNotInPackageJson: isDisabledIfNotInPackageJson,
   isFormatOnSaveEnabled: isFormatOnSaveEnabled,

--- a/dist/config-schema.json
+++ b/dist/config-schema.json
@@ -46,8 +46,8 @@
         "default": false,
         "order": 3
       },
-      "scopes": {
-        "title": "Scopes",
+      "javascriptScopes": {
+        "title": "JS Scopes",
         "description": "Use `Editor: Log Cursor Scope` to determine the scopes for a file.",
         "type": "array",
         "default": [
@@ -64,26 +64,52 @@
         },
         "order": 4
       },
+      "typescriptScopes": {
+        "title": "Typescript Scopes",
+        "description": "Use `Editor: Log Cursor Scope` to determine the scopes for a file.",
+        "type": "array",
+        "default": [
+          "source.ts",
+          "source.tsx",
+          "source.ts.tsx"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "order": 5
+      },
+      "cssScopes": {
+        "title": "CSS Scopes",
+        "description": "Use `Editor: Log Cursor Scope` to determine the scopes for a file.",
+        "type": "array",
+        "default": [
+          "source.css"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "order": 6
+      },
       "excludedGlobs": {
         "title": "Exclude (list of globs)",
         "description": "A list of file globs to exclude from formatting on save (takes precedence over scopes). Use commas to seperate each glob.",
         "type": "array",
         "default": [],
-        "order": 5
+        "order": 7
       },
       "whitelistedGlobs": {
         "title": "Include (list of globs)",
         "description": "A list of file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to seperate each glob. NOTE: If there are globs in this list, files not matching the globs will not be formatted on save regardless of other options.",
         "type": "array",
         "default": [],
-        "order": 6
+        "order": 8
       },
       "isDisabledIfNotInPackageJson": {
         "title": "Only format if prettier is found in your project's dependencies",
         "description": "Does not format on save if prettier (or prettier-eslint/prettier-eslint-cli if using eslint integration) is in your project's package.json (dependencies or devDependencies)",
         "type": "boolean",
         "default": false,
-        "order": 7
+        "order": 9
       }
     }
   },
@@ -153,15 +179,13 @@
         "order": 8
       },
       "parser": {
-        "title": "Parser",
-        "description": "Choose which [supported parser](https://www.npmjs.com/package/prettier#language-support) to use.",
+        "title": "Javascript Parser",
+        "description": "Choose which [supported parser](https://www.npmjs.com/package/prettier#language-support) to use. (Does not apply to Typescript or CSS)",
         "type": "string",
         "default": "babylon",
         "enum": [
           "babylon",
-          "flow",
-          "typescript",
-          "postcss"
+          "flow"
         ],
         "order": 9
       }

--- a/dist/editorInterface/index.js
+++ b/dist/editorInterface/index.js
@@ -3,6 +3,10 @@
 var _ = require('lodash/fp');
 var path = require('path');
 
+var _require = require('../atomInterface'),
+    getCssScopes = _require.getCssScopes,
+    getTypescriptScopes = _require.getTypescriptScopes;
+
 var EMBEDDED_SCOPES = ['text.html.vue', 'text.html.basic'];
 
 var getBufferRange = function getBufferRange(editor) {
@@ -17,6 +21,14 @@ var isCurrentScopeEmbeddedScope = function isCurrentScopeEmbeddedScope(editor) {
   return EMBEDDED_SCOPES.includes(getCurrentScope(editor));
 };
 
+var isCurrentScopeCssScope = function isCurrentScopeCssScope(editor) {
+  return getCssScopes().includes(getCurrentScope(editor));
+};
+
+var isCurrentScopeTypescriptScope = function isCurrentScopeTypescriptScope(editor) {
+  return getTypescriptScopes().includes(getCurrentScope(editor));
+};
+
 var getCurrentFilePath = function getCurrentFilePath(editor) {
   return editor.buffer.file ? editor.buffer.file.path : undefined;
 };
@@ -28,6 +40,8 @@ var getCurrentDir = _.flow(getCurrentFilePath, function (maybeFilePath) {
 module.exports = {
   getBufferRange: getBufferRange,
   isCurrentScopeEmbeddedScope: isCurrentScopeEmbeddedScope,
+  isCurrentScopeCssScope: isCurrentScopeCssScope,
+  isCurrentScopeTypescriptScope: isCurrentScopeTypescriptScope,
   getCurrentScope: getCurrentScope,
   getCurrentFilePath: getCurrentFilePath,
   getCurrentDir: getCurrentDir

--- a/dist/executePrettier/buildPrettierOptions.js
+++ b/dist/executePrettier/buildPrettierOptions.js
@@ -5,7 +5,9 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 var _ = require('lodash/fp');
 
 var _require = require('../editorInterface'),
-    getCurrentFilePath = _require.getCurrentFilePath;
+    getCurrentFilePath = _require.getCurrentFilePath,
+    isCurrentScopeTypescriptScope = _require.isCurrentScopeTypescriptScope,
+    isCurrentScopeCssScope = _require.isCurrentScopeCssScope;
 
 var _require2 = require('../atomInterface'),
     shouldUseEditorConfig = _require2.shouldUseEditorConfig,
@@ -25,6 +27,14 @@ var buildPrettierOptions = function buildPrettierOptions(editor) {
 
   if (optionsFromSettings.tabWidth === 'auto') {
     optionsFromSettings.tabWidth = getAtomTabLength(editor);
+  }
+
+  if (isCurrentScopeTypescriptScope(editor)) {
+    optionsFromSettings.parser = 'typescript';
+  }
+
+  if (isCurrentScopeCssScope(editor)) {
+    optionsFromSettings.parser = 'postcss';
   }
 
   return _extends({}, optionsFromSettings, buildEditorConfigOptionsIfAppropriate(editor));

--- a/dist/formatOnSave/shouldFormatOnSave.js
+++ b/dist/formatOnSave/shouldFormatOnSave.js
@@ -11,7 +11,7 @@ var _require2 = require('../editorInterface'),
 
 var _require3 = require('../atomInterface'),
     isFormatOnSaveEnabled = _require3.isFormatOnSaveEnabled,
-    getScopes = _require3.getScopes,
+    getAllScopes = _require3.getAllScopes,
     getExcludedGlobs = _require3.getExcludedGlobs,
     getWhitelistedGlobs = _require3.getWhitelistedGlobs,
     isDisabledIfNotInPackageJson = _require3.isDisabledIfNotInPackageJson;
@@ -24,7 +24,7 @@ var hasFilePath = function hasFilePath(editor) {
 };
 
 var isInScope = function isInScope(editor) {
-  return getScopes().includes(getCurrentScope(editor));
+  return getAllScopes().includes(getCurrentScope(editor));
 };
 
 var filePathDoesNotMatchBlacklistGlobs = _.flow(getCurrentFilePath, function (filePath) {

--- a/src/atomInterface/index.js
+++ b/src/atomInterface/index.js
@@ -30,7 +30,13 @@ const isDisabledIfNotInPackageJson = () =>
 
 const shouldRespectEslintignore = () => getConfigOption('formatOnSaveOptions.respectEslintignore');
 
-const getScopes = () => getConfigOption('formatOnSaveOptions.scopes');
+const getJavascriptScopes = () => getConfigOption('formatOnSaveOptions.javascriptScopes');
+
+const getTypescriptScopes = () => getConfigOption('formatOnSaveOptions.typescriptScopes');
+
+const getCssScopes = () => getConfigOption('formatOnSaveOptions.cssScopes');
+
+const getAllScopes = () => [...getJavascriptScopes(), ...getTypescriptScopes(), ...getCssScopes()];
 
 const getWhitelistedGlobs = () => getConfigOption('formatOnSaveOptions.whitelistedGlobs');
 
@@ -76,7 +82,10 @@ module.exports = {
   getPrettierAtomConfig,
   getPrettierEslintOptions,
   getPrettierOptions,
-  getScopes,
+  getJavascriptScopes,
+  getTypescriptScopes,
+  getCssScopes,
+  getAllScopes,
   getWhitelistedGlobs,
   isDisabledIfNotInPackageJson,
   isFormatOnSaveEnabled,

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -46,8 +46,8 @@
         "default": false,
         "order": 3
       },
-      "scopes": {
-        "title": "Scopes",
+      "javascriptScopes": {
+        "title": "JS Scopes",
         "description": "Use `Editor: Log Cursor Scope` to determine the scopes for a file.",
         "type": "array",
         "default": [
@@ -64,26 +64,52 @@
         },
         "order": 4
       },
+      "typescriptScopes": {
+        "title": "Typescript Scopes",
+        "description": "Use `Editor: Log Cursor Scope` to determine the scopes for a file.",
+        "type": "array",
+        "default": [
+          "source.ts",
+          "source.tsx",
+          "source.ts.tsx"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "order": 5
+      },
+      "cssScopes": {
+        "title": "CSS Scopes",
+        "description": "Use `Editor: Log Cursor Scope` to determine the scopes for a file.",
+        "type": "array",
+        "default": [
+          "source.css"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "order": 6
+      },
       "excludedGlobs": {
         "title": "Exclude (list of globs)",
         "description": "A list of file globs to exclude from formatting on save (takes precedence over scopes). Use commas to seperate each glob.",
         "type": "array",
         "default": [],
-        "order": 5
+        "order": 7
       },
       "whitelistedGlobs": {
         "title": "Include (list of globs)",
         "description": "A list of file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to seperate each glob. NOTE: If there are globs in this list, files not matching the globs will not be formatted on save regardless of other options.",
         "type": "array",
         "default": [],
-        "order": 6
+        "order": 8
       },
       "isDisabledIfNotInPackageJson": {
         "title": "Only format if prettier is found in your project's dependencies",
         "description": "Does not format on save if prettier (or prettier-eslint/prettier-eslint-cli if using eslint integration) is in your project's package.json (dependencies or devDependencies)",
         "type": "boolean",
         "default": false,
-        "order": 7
+        "order": 9
       }
     }
   },
@@ -153,15 +179,13 @@
         "order": 8
       },
       "parser": {
-        "title": "Parser",
-        "description": "Choose which [supported parser](https://www.npmjs.com/package/prettier#language-support) to use.",
+        "title": "Javascript Parser",
+        "description": "Choose which [supported parser](https://www.npmjs.com/package/prettier#language-support) to use. (Does not apply to Typescript or CSS)",
         "type": "string",
         "default": "babylon",
         "enum": [
           "babylon",
-          "flow",
-          "typescript",
-          "postcss"
+          "flow"
         ],
         "order": 9
       }

--- a/src/editorInterface/index.js
+++ b/src/editorInterface/index.js
@@ -2,6 +2,8 @@
 const _ = require('lodash/fp');
 const path = require('path');
 
+const { getCssScopes, getTypescriptScopes } = require('../atomInterface');
+
 const EMBEDDED_SCOPES = ['text.html.vue', 'text.html.basic'];
 
 const getBufferRange = (editor: TextEditor) => editor.getBuffer().getRange();
@@ -9,6 +11,11 @@ const getBufferRange = (editor: TextEditor) => editor.getBuffer().getRange();
 const getCurrentScope = (editor: TextEditor) => editor.getGrammar().scopeName;
 
 const isCurrentScopeEmbeddedScope = (editor: TextEditor) => EMBEDDED_SCOPES.includes(getCurrentScope(editor));
+
+const isCurrentScopeCssScope = (editor: TextEditor) => getCssScopes().includes(getCurrentScope(editor));
+
+const isCurrentScopeTypescriptScope = (editor: TextEditor) =>
+  getTypescriptScopes().includes(getCurrentScope(editor));
 
 const getCurrentFilePath = (editor: TextEditor) => (editor.buffer.file ? editor.buffer.file.path : undefined);
 
@@ -20,6 +27,8 @@ const getCurrentDir: (editor: TextEditor) => ?string = _.flow(
 module.exports = {
   getBufferRange,
   isCurrentScopeEmbeddedScope,
+  isCurrentScopeCssScope,
+  isCurrentScopeTypescriptScope,
   getCurrentScope,
   getCurrentFilePath,
   getCurrentDir,

--- a/src/editorInterface/index.test.js
+++ b/src/editorInterface/index.test.js
@@ -1,8 +1,13 @@
+jest.mock('../atomInterface');
+
 const buildMockTextEditor = require('../../tests/mocks/textEditor');
+const { getCssScopes, getTypescriptScopes } = require('../atomInterface');
 const {
   getBufferRange,
   getCurrentScope,
   isCurrentScopeEmbeddedScope,
+  isCurrentScopeCssScope,
+  isCurrentScopeTypescriptScope,
   getCurrentFilePath,
 } = require('./index');
 
@@ -26,7 +31,7 @@ describe('getCurrentScope()', () => {
   });
 });
 
-describe('isCurrentScopeEmbeddedScope', () => {
+describe('isCurrentScopeEmbeddedScope()', () => {
   it('returns true if the current scope is an embedded scope type', () => {
     const scopeName = 'text.html.basic';
     const editor = buildMockTextEditor({ getGrammar: () => ({ scopeName }) });
@@ -41,6 +46,50 @@ describe('isCurrentScopeEmbeddedScope', () => {
     const editor = buildMockTextEditor({ getGrammar: () => ({ scopeName }) });
 
     const actual = isCurrentScopeEmbeddedScope(editor);
+
+    expect(actual).toBe(false);
+  });
+});
+
+describe('isCurrentScopeCssScope()', () => {
+  it('returns true if the current scope is a CSS scope type', () => {
+    const scopeName = 'src.typescript';
+    const editor = buildMockTextEditor({ getGrammar: () => ({ scopeName }) });
+    getCssScopes.mockImplementation(() => ['src.typescript']);
+
+    const actual = isCurrentScopeCssScope(editor);
+
+    expect(actual).toBe(true);
+  });
+
+  it('returns false if the current scope is not a CSS scope type', () => {
+    const scopeName = 'src.python';
+    const editor = buildMockTextEditor({ getGrammar: () => ({ scopeName }) });
+    getCssScopes.mockImplementation(() => ['src.typescript']);
+
+    const actual = isCurrentScopeCssScope(editor);
+
+    expect(actual).toBe(false);
+  });
+});
+
+describe('isCurrentScopeTypescriptScope()', () => {
+  it('returns true if the current scope is a typescript scope type', () => {
+    const scopeName = 'src.typescript';
+    const editor = buildMockTextEditor({ getGrammar: () => ({ scopeName }) });
+    getTypescriptScopes.mockImplementation(() => ['src.typescript']);
+
+    const actual = isCurrentScopeTypescriptScope(editor);
+
+    expect(actual).toBe(true);
+  });
+
+  it('returns false if the current scope is not a typescript scope type', () => {
+    const scopeName = 'src.python';
+    const editor = buildMockTextEditor({ getGrammar: () => ({ scopeName }) });
+    getTypescriptScopes.mockImplementation(() => ['src.typescript']);
+
+    const actual = isCurrentScopeTypescriptScope(editor);
 
     expect(actual).toBe(false);
   });

--- a/src/executePrettier/buildPrettierOptions.js
+++ b/src/executePrettier/buildPrettierOptions.js
@@ -1,6 +1,10 @@
 // @flow
 const _ = require('lodash/fp');
-const { getCurrentFilePath } = require('../editorInterface');
+const {
+  getCurrentFilePath,
+  isCurrentScopeTypescriptScope,
+  isCurrentScopeCssScope,
+} = require('../editorInterface');
 const { shouldUseEditorConfig, getPrettierOptions, getAtomTabLength } = require('../atomInterface');
 const buildEditorConfigOptions = require('./buildEditorConfigOptions');
 
@@ -21,6 +25,14 @@ const buildPrettierOptions = (editor: TextEditor) => {
 
   if (optionsFromSettings.tabWidth === 'auto') {
     optionsFromSettings.tabWidth = getAtomTabLength(editor);
+  }
+
+  if (isCurrentScopeTypescriptScope(editor)) {
+    optionsFromSettings.parser = 'typescript';
+  }
+
+  if (isCurrentScopeCssScope(editor)) {
+    optionsFromSettings.parser = 'postcss';
   }
 
   return {

--- a/src/executePrettier/buildPrettierOptions.test.js
+++ b/src/executePrettier/buildPrettierOptions.test.js
@@ -1,7 +1,13 @@
 jest.mock('../atomInterface');
+jest.mock('../editorInterface');
 jest.mock('./buildEditorConfigOptions');
 
 const { getPrettierOptions, getAtomTabLength, shouldUseEditorConfig } = require('../atomInterface');
+const {
+  getCurrentFilePath,
+  isCurrentScopeTypescriptScope,
+  isCurrentScopeCssScope,
+} = require('../editorInterface');
 const buildEditorConfigOptions = require('./buildEditorConfigOptions');
 const buildMockEditor = require('../../tests/mocks/textEditor');
 const buildPrettierOptions = require('./buildPrettierOptions');
@@ -27,6 +33,28 @@ it('uses the atom tab length if the tabWidth option is set to "auto"', () => {
   expect(actual).toEqual({ tabWidth: 2 });
 });
 
+it('uses typescript as the parser if current scope is listed as a typescript scope in settings', () => {
+  const editor = buildMockEditor();
+  const fakePrettierOptions = { parser: 'babylon' };
+  getPrettierOptions.mockImplementation(() => fakePrettierOptions);
+  isCurrentScopeTypescriptScope.mockImplementation(() => true);
+
+  const actual = buildPrettierOptions(editor);
+
+  expect(actual).toEqual({ parser: 'typescript' });
+});
+
+it('uses postcss as the parser if current scope is listed as a CSS scope in settings', () => {
+  const editor = buildMockEditor();
+  const fakePrettierOptions = { parser: 'babylon' };
+  getPrettierOptions.mockImplementation(() => fakePrettierOptions);
+  isCurrentScopeCssScope.mockImplementation(() => true);
+
+  const actual = buildPrettierOptions(editor);
+
+  expect(actual).toEqual({ parser: 'postcss' });
+});
+
 it('does not use editorconfig options if that setting is not enabled', () => {
   const editor = buildMockEditor();
   getPrettierOptions.mockImplementation(() => ({}));
@@ -44,6 +72,7 @@ it('overrides values with editorconfig values if editor config is enabled', () =
   getPrettierOptions.mockImplementation(() => fakePrettierOptions);
   buildEditorConfigOptions.mockImplementation(() => fakeEditorConfigOptions);
   shouldUseEditorConfig.mockImplementation(() => true);
+  getCurrentFilePath.mockImplementation(() => 'parent-dir/foo.js');
 
   const actual = buildPrettierOptions(editor);
 

--- a/src/formatOnSave/shouldFormatOnSave.js
+++ b/src/formatOnSave/shouldFormatOnSave.js
@@ -4,7 +4,7 @@ const { someGlobsMatchFilePath } = require('../helpers');
 const { getCurrentFilePath, getCurrentScope } = require('../editorInterface');
 const {
   isFormatOnSaveEnabled,
-  getScopes,
+  getAllScopes,
   getExcludedGlobs,
   getWhitelistedGlobs,
   isDisabledIfNotInPackageJson,
@@ -14,7 +14,7 @@ const isPrettierInPackageJson = require('./isPrettierInPackageJson');
 
 const hasFilePath = (editor: TextEditor) => !!getCurrentFilePath(editor);
 
-const isInScope = (editor: TextEditor) => getScopes().includes(getCurrentScope(editor));
+const isInScope = (editor: TextEditor) => getAllScopes().includes(getCurrentScope(editor));
 
 const filePathDoesNotMatchBlacklistGlobs: (
   editor: TextEditor,

--- a/src/formatOnSave/shouldFormatOnSave.test.js
+++ b/src/formatOnSave/shouldFormatOnSave.test.js
@@ -9,7 +9,7 @@ const {
   isFormatOnSaveEnabled,
   getExcludedGlobs,
   getWhitelistedGlobs,
-  getScopes,
+  getAllScopes,
 } = require('../atomInterface');
 const { getCurrentScope, getCurrentFilePath } = require('../editorInterface');
 const isFilePathEslintIgnored = require('./isFilePathEslintIgnored');
@@ -21,7 +21,7 @@ const callShouldFormatOnSave = () => shouldFormatOnSave(createMockTextEditor());
 
 beforeEach(() => {
   isFormatOnSaveEnabled.mockImplementation(() => true);
-  getScopes.mockImplementation(() => ['js', 'jsx']);
+  getAllScopes.mockImplementation(() => ['js', 'jsx']);
   getCurrentScope.mockImplementation(() => 'js');
   getCurrentFilePath.mockImplementation(() => fakeCurrentFilePath);
   isFilePathEslintIgnored.mockImplementation(() => false);


### PR DESCRIPTION
We now allow adding scopes (some defaults have already been provided for you) for typescript and
CSS. If we recognize the text you are trying to format as being one of these scopes, we will
automatically use the appropriate parser.

Resolves #183 
Resolves #184