### PR TITLE
fix(save): On save, use editor provided by observer

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -33,10 +33,8 @@ var lazyFormat = function lazyFormat() {
 };
 
 // HACK: lazy load most of the code we need for performance
-var lazyFormatOnSave = function lazyFormatOnSave() {
+var lazyFormatOnSave = function lazyFormatOnSave(editor) {
   if (!formatOnSave) formatOnSave = require('./formatOnSave'); // eslint-disable-line global-require
-
-  var editor = atom.workspace.getActiveTextEditor();
   if (editor) formatOnSave(editor);
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -23,10 +23,8 @@ const lazyFormat = () => {
 };
 
 // HACK: lazy load most of the code we need for performance
-const lazyFormatOnSave = () => {
+const lazyFormatOnSave = (editor) => {
   if (!formatOnSave) formatOnSave = require('./formatOnSave'); // eslint-disable-line global-require
-
-  const editor = atom.workspace.getActiveTextEditor();
   if (editor) formatOnSave(editor);
 };
 


### PR DESCRIPTION
We fetched the active text editor on every save, which prevented formatting all saved files.

Fixes #96