### PR TITLE
docs(changelog): fix prettier version in 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Features
 
-* **prettier:** bump to 0.4.1 ([1791886](https://github.com/prettier/prettier-atom/commit/1791886))
+* **prettier:** bump to 1.4.1 ([1791886](https://github.com/prettier/prettier-atom/commit/1791886))
 
 
 


### PR DESCRIPTION
The wrong version was mentioned due to a typo in 499516f.