### PR TITLE
Correct message for isDisabledIfNotInPackageJson

### DIFF
--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -110,7 +110,7 @@
       },
       "isDisabledIfNotInPackageJson": {
         "title": "Only format if Prettier is found in your project's dependencies",
-        "description": "Does not format on save if `prettier` (or `prettier-eslint`/`prettier-eslint-cli` if using *ESLint integration*) is in your project's `package.json` (dependencies or devDependencies)",
+        "description": "Does not format on save if `prettier` (or `prettier-eslint`/`prettier-eslint-cli` if using *ESLint integration*) is not in your project's `package.json` (dependencies or devDependencies)",
         "type": "boolean",
         "default": false,
         "order": 9


### PR DESCRIPTION
> Does not format on save if `prettier` (or `prettier-eslint`/`prettier-eslint-cli` if using *ESLint integration*) is **not** in your project's `package.json` (dependencies or devDependencies)

Added `not` into the message.  I didn't enable it because I thought this was saying it would run the `prettier` dependency that existed in my `package.json`.