### PR TITLE
fix(main): Subscribe to onDidChangeActivePaneItem when onDidChangeActiveTextEditor is not available

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -77,8 +77,12 @@ var attachStatusTile = function attachStatusTile() {
     subscriptions.add(atom.config.observe('prettier-atom.formatOnSaveOptions.enabled', function () {
       return updateStatusTile(subscriptions, tileElement);
     }));
-    subscriptions.add(atom.workspace.onDidChangeActiveTextEditor(function (editor) {
+    subscriptions.add(
+    // onDidChangeActiveTextEditor is only available in Atom 1.18.0+.
+    atom.workspace.onDidChangeActiveTextEditor ? atom.workspace.onDidChangeActiveTextEditor(function (editor) {
       return updateStatusTileScope(tileElement, editor);
+    }) : atom.workspace.onDidChangeActivePaneItem(function () {
+      return updateStatusTileScope(tileElement, atom.workspace.getActiveTextEditor());
     }));
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -69,7 +69,12 @@ const attachStatusTile = () => {
       ),
     );
     subscriptions.add(
-      atom.workspace.onDidChangeActiveTextEditor(editor => updateStatusTileScope(tileElement, editor)),
+      // onDidChangeActiveTextEditor is only available in Atom 1.18.0+.
+      atom.workspace.onDidChangeActiveTextEditor
+        ? atom.workspace.onDidChangeActiveTextEditor(editor => updateStatusTileScope(tileElement, editor))
+        : atom.workspace.onDidChangeActivePaneItem(() =>
+          updateStatusTileScope(tileElement, atom.workspace.getActiveTextEditor()),
+        ),
     );
   }
 };


### PR DESCRIPTION
`onDidChangeActiveTextEditor` is available on Atom 1.18.0+ only. This avoids throwing errors for users
that are still using old versions of Atom.

Fixes #205