### PR TITLE
test(buildPrettierOptions): fix json scope test

### DIFF
--- a/src/executePrettier/buildPrettierOptions.test.js
+++ b/src/executePrettier/buildPrettierOptions.test.js
@@ -64,7 +64,7 @@ it('uses json as the parser if current scope is listed as a JSON scope in settin
 
   const actual = buildPrettierOptions(editor);
 
-  expect(actual).toEqual({ parser: 'json' });
+  expect(actual).toEqual({ parser: 'json', trailingComma: 'none' });
 });
 
 it('does not use editorconfig options if that setting is not enabled', () => {


### PR DESCRIPTION
Our json scope test will now check for disabling of trailing commas, as prettier erroneously adds
trailing commas in JSON files otherwise.