### PR TITLE
fix(debug): Fix usage of readPkgUp to fetch package info

### DIFF
--- a/dist/displayDebugInfo/index.js
+++ b/dist/displayDebugInfo/index.js
@@ -12,8 +12,12 @@ var getDepPath = function getDepPath(dep) {
   return path.join(__dirname, '..', '..', 'node_modules', dep);
 };
 
+var getPackageInfo = function getPackageInfo(dir) {
+  return readPkgUp.sync({ cwd: dir }).pkg;
+};
+
 var getDebugInfo = function getDebugInfo() {
-  return ('\nAtom version: ' + getAtomVersion() + '\nprettier-atom version: ' + readPkgUp.sync(__dirname).version + '\nprettier version: ' + readPkgUp.sync(getDepPath('prettier')).version + '\nprettier-eslint version: ' + readPkgUp.sync(getDepPath('prettier-eslint')).version + '\nprettier-atom configuration: ' + JSON.stringify(getPrettierAtomConfig(), null, 2) + '\n').trim();
+  return ('\nAtom version: ' + getAtomVersion() + '\nprettier-atom version: ' + getPackageInfo(__dirname).version + '\nprettier version: ' + getPackageInfo(getDepPath('prettier')).version + '\nprettier-eslint version: ' + getPackageInfo(getDepPath('prettier-eslint')).version + '\nprettier-atom configuration: ' + JSON.stringify(getPrettierAtomConfig(), null, 2) + '\n').trim();
 };
 
 var displayDebugInfo = function displayDebugInfo() {

--- a/src/displayDebugInfo/index.js
+++ b/src/displayDebugInfo/index.js
@@ -5,12 +5,14 @@ const { getAtomVersion, getPrettierAtomConfig, addInfoNotification } = require('
 
 const getDepPath = (dep: string) => path.join(__dirname, '..', '..', 'node_modules', dep);
 
+const getPackageInfo = (dir: string) => readPkgUp.sync({ cwd: dir }).pkg;
+
 const getDebugInfo = () =>
   `
 Atom version: ${getAtomVersion()}
-prettier-atom version: ${readPkgUp.sync(__dirname).version}
-prettier version: ${readPkgUp.sync(getDepPath('prettier')).version}
-prettier-eslint version: ${readPkgUp.sync(getDepPath('prettier-eslint')).version}
+prettier-atom version: ${getPackageInfo(__dirname).version}
+prettier version: ${getPackageInfo(getDepPath('prettier')).version}
+prettier-eslint version: ${getPackageInfo(getDepPath('prettier-eslint')).version}
 prettier-atom configuration: ${JSON.stringify(getPrettierAtomConfig(), null, 2)}
 `.trim();
 

--- a/src/displayDebugInfo/index.test.js
+++ b/src/displayDebugInfo/index.test.js
@@ -12,7 +12,11 @@ test('it displays a notification on Atom with package information', () => {
     title = _title;
     options = _options;
   });
-  readPkgUp.sync.mockImplementation(() => ({ version: 'FAKE_PACKAGE_VERSION' }));
+  readPkgUp.sync.mockImplementation(() => ({
+    pkg: {
+      version: 'FAKE_PACKAGE_VERSION',
+    },
+  }));
   getAtomVersion.mockImplementation(() => 'FAKE_ATOM_VERSION');
   getPrettierAtomConfig.mockImplementation(() => 'FAKE_PRETTIER_ATOM_CONFIG');
 


### PR DESCRIPTION
read-pkg and read-pkg-up do not have the same API.

Fixes #217