### PR TITLE
fix(formatOnSave): don't prevent user from saving if uncaught error

### DIFF
--- a/dist/atomInterface/index.js
+++ b/dist/atomInterface/index.js
@@ -117,6 +117,18 @@ var addErrorNotification = function addErrorNotification(message, options) {
   return atom.notifications.addError(message, options);
 };
 
+var attemptWithErrorNotification = function attemptWithErrorNotification(func) {
+  for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    args[_key - 1] = arguments[_key];
+  }
+
+  try {
+    func.apply(undefined, args);
+  } catch (e) {
+    addErrorNotification(e.message, { dismissable: true, detail: e.stack });
+  }
+};
+
 var runLinter = function runLinter(editor) {
   return isLinterLintCommandDefined(editor) && atom.commands.dispatch(atom.views.getView(editor), LINTER_LINT_COMMAND);
 };
@@ -146,5 +158,6 @@ module.exports = {
   shouldRespectEslintignore: shouldRespectEslintignore,
   shouldUseEditorConfig: shouldUseEditorConfig,
   shouldUseEslint: shouldUseEslint,
-  toggleFormatOnSave: toggleFormatOnSave
+  toggleFormatOnSave: toggleFormatOnSave,
+  attemptWithErrorNotification: attemptWithErrorNotification
 };

--- a/dist/formatOnSave/index.js
+++ b/dist/formatOnSave/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _ = require('lodash/fp');
+
 var _require = require('../editorInterface'),
     isCurrentScopeEmbeddedScope = _require.isCurrentScopeEmbeddedScope,
     getBufferRange = _require.getBufferRange;
@@ -8,10 +10,21 @@ var _require2 = require('../executePrettier'),
     executePrettierOnBufferRange = _require2.executePrettierOnBufferRange,
     executePrettierOnEmbeddedScripts = _require2.executePrettierOnEmbeddedScripts;
 
+var _require3 = require('../atomInterface'),
+    attemptWithErrorNotification = _require3.attemptWithErrorNotification;
+
 var shouldFormatOnSave = require('./shouldFormatOnSave');
 
-var formatOnSaveIfAppropriate = function formatOnSaveIfAppropriate(editor) {
-  return shouldFormatOnSave(editor) && (isCurrentScopeEmbeddedScope(editor) ? executePrettierOnEmbeddedScripts(editor) : executePrettierOnBufferRange(editor, getBufferRange(editor)));
+var callAppropriatePrettierExecutor = function callAppropriatePrettierExecutor(editor) {
+  return isCurrentScopeEmbeddedScope(editor) ? executePrettierOnEmbeddedScripts(editor) : executePrettierOnBufferRange(editor, getBufferRange(editor));
 };
 
-module.exports = formatOnSaveIfAppropriate;
+var formatOnSaveIfAppropriate = _.cond([[shouldFormatOnSave, callAppropriatePrettierExecutor]]);
+
+var safeFormatOnSaveIfAppropriate = function safeFormatOnSaveIfAppropriate(editor) {
+  return attemptWithErrorNotification(function () {
+    return formatOnSaveIfAppropriate(editor);
+  });
+};
+
+module.exports = safeFormatOnSaveIfAppropriate;

--- a/src/atomInterface/index.js
+++ b/src/atomInterface/index.js
@@ -74,6 +74,14 @@ const addWarningNotification = (message: string, options?: Atom$Notifications$Op
 const addErrorNotification = (message: string, options?: Atom$Notifications$Options) =>
   atom.notifications.addError(message, options);
 
+const attemptWithErrorNotification = (func: Function, ...args: Array<any>) => {
+  try {
+    func(...args);
+  } catch (e) {
+    addErrorNotification(e.message, { dismissable: true, detail: e.stack });
+  }
+};
+
 const runLinter = (editor: TextEditor) =>
   isLinterLintCommandDefined(editor) &&
   atom.commands.dispatch(atom.views.getView(editor), LINTER_LINT_COMMAND);
@@ -104,4 +112,5 @@ module.exports = {
   shouldUseEditorConfig,
   shouldUseEslint,
   toggleFormatOnSave,
+  attemptWithErrorNotification,
 };

--- a/src/formatOnSave/index.js
+++ b/src/formatOnSave/index.js
@@ -1,12 +1,20 @@
 // @flow
+const _ = require('lodash/fp');
 const { isCurrentScopeEmbeddedScope, getBufferRange } = require('../editorInterface');
 const { executePrettierOnBufferRange, executePrettierOnEmbeddedScripts } = require('../executePrettier');
+const { attemptWithErrorNotification } = require('../atomInterface');
 const shouldFormatOnSave = require('./shouldFormatOnSave');
 
-const formatOnSaveIfAppropriate = (editor: TextEditor) =>
-  shouldFormatOnSave(editor) &&
-  (isCurrentScopeEmbeddedScope(editor)
+const callAppropriatePrettierExecutor = (editor: TextEditor) =>
+  isCurrentScopeEmbeddedScope(editor)
     ? executePrettierOnEmbeddedScripts(editor)
-    : executePrettierOnBufferRange(editor, getBufferRange(editor)));
+    : executePrettierOnBufferRange(editor, getBufferRange(editor));
 
-module.exports = formatOnSaveIfAppropriate;
+const formatOnSaveIfAppropriate: TextEditor => void = _.cond([
+  [shouldFormatOnSave, callAppropriatePrettierExecutor],
+]);
+
+const safeFormatOnSaveIfAppropriate = (editor: TextEditor) =>
+  attemptWithErrorNotification(() => formatOnSaveIfAppropriate(editor));
+
+module.exports = safeFormatOnSaveIfAppropriate;

--- a/src/formatOnSave/index.test.js
+++ b/src/formatOnSave/index.test.js
@@ -40,3 +40,16 @@ it('does nothing if it should not format on save', () => {
   expect(executePrettierOnBufferRange).not.toHaveBeenCalled();
   expect(executePrettierOnEmbeddedScripts).not.toHaveBeenCalled();
 });
+
+it('catches uncaught errors so that the user is not prevented from saving', () => {
+  const editor = createMockTextEditor();
+  const fakeError = new Error('fake error');
+  atom = { notifications: { addError: jest.fn() } };
+  shouldFormatOnSave.mockImplementation(() => {
+    throw fakeError;
+  });
+
+  formatOnSave(editor);
+
+  expect(atom.notifications.addError).toHaveBeenCalled();
+});


### PR DESCRIPTION
In unexpected situations where errors other than parsing errors during formatting are raised (the
latter already being handled), users are unable to save without disabling prettier because the Error
prevents the save from executing. Now we will wrap the logic inside of `formatOnSave` with a
try/catch that will catch this error and show a notification. This will inform the user that an
error occurred, but won't prevent saving their file.

Resolves #190