### PR TITLE
fix(handleError): properly handle alternative loc in Prettier errors

### DIFF
--- a/decls/index.js
+++ b/decls/index.js
@@ -89,7 +89,7 @@ declare type Linter$Message$ApplySolution = {
 };
 // eslint-disable-next-line no-undef
 declare type Prettier$SyntaxError = {
-  loc: { start: { line: number, column: number } },
+  loc: { start: { line: number, column: number } } | {| line: number, column: number |},
   message: string,
 };
 declare type Linter$Message = {
@@ -136,5 +136,4 @@ declare type Linter$IndieDelegate = {
   setAllMessages: (messages: Array<Linter$Message>) => void,
   onDidUpdate: (callback: Function) => Atom$Disposable,
   onDidDestroy: (callback: Function) => Atom$Disposable,
-  dispose: () => void,
 };

--- a/dist/executePrettier/handleError.js
+++ b/dist/executePrettier/handleError.js
@@ -11,9 +11,17 @@ var _require2 = require('../helpers'),
     createPoint = _require2.createPoint,
     createRange = _require2.createRange;
 
+var errorLine = function errorLine(error) {
+  return error.loc.start ? error.loc.start.line : error.loc.line;
+};
+
+var errorColumn = function errorColumn(error) {
+  return error.loc.start ? error.loc.start.column : error.loc.column;
+};
+
 // NOTE: Prettier error locations are not zero-based (i.e., they start at 1)
 var buildPointArrayFromPrettierErrorAndRange = function buildPointArrayFromPrettierErrorAndRange(error, bufferRange) {
-  return createPoint(error.loc.start.line + bufferRange.start.row - 1, error.loc.start.line === 0 ? error.loc.start.column + bufferRange.start.column - 1 : error.loc.start.column - 1);
+  return createPoint(errorLine(error) + bufferRange.start.row - 1, errorLine(error) === 0 ? errorColumn(error) + bufferRange.start.column - 1 : errorColumn(error) - 1);
 };
 
 var buildExcerpt = function buildExcerpt(error) {

--- a/src/executePrettier/handleError.js
+++ b/src/executePrettier/handleError.js
@@ -10,13 +10,16 @@ type HandleErrorArgs = {
   bufferRange: Range,
 };
 
+const errorLine = (error: Prettier$SyntaxError) => (error.loc.start ? error.loc.start.line : error.loc.line);
+
+const errorColumn = (error: Prettier$SyntaxError) =>
+  error.loc.start ? error.loc.start.column : error.loc.column;
+
 // NOTE: Prettier error locations are not zero-based (i.e., they start at 1)
 const buildPointArrayFromPrettierErrorAndRange = (error: Prettier$SyntaxError, bufferRange: Range): Point =>
   createPoint(
-    error.loc.start.line + bufferRange.start.row - 1,
-    error.loc.start.line === 0
-      ? error.loc.start.column + bufferRange.start.column - 1
-      : error.loc.start.column - 1,
+    errorLine(error) + bufferRange.start.row - 1,
+    errorLine(error) === 0 ? errorColumn(error) + bufferRange.start.column - 1 : errorColumn(error) - 1,
   );
 
 const buildExcerpt = (error: Prettier$SyntaxError) => /(.*)\s\(\d+:\d+\).*/.exec(error.message)[1];


### PR DESCRIPTION
Prettier sometimes provides a different API for the `loc` property on the errors it throws. We were
only anticipating one type, where there is a `start` property nested in `loc`, but there's actually
another where the line and column are direct children of `loc` and there is no `start` property. We
now will properly handle either case.

Fixes #229