### PR TITLE
fix(errors): handle errors that aren't syntax errors

### DIFF
--- a/decls/index.js
+++ b/decls/index.js
@@ -91,6 +91,7 @@ declare type Linter$Message$ApplySolution = {
 declare type Prettier$SyntaxError = {
   loc: { start: { line: number, column: number } } | {| line: number, column: number |},
   message: string,
+  stack: string,
 };
 declare type Linter$Message = {
   // NOTE: These are given by providers

--- a/dist/executePrettier/handleError.js
+++ b/dist/executePrettier/handleError.js
@@ -7,9 +7,12 @@ var _require = require('../editorInterface'),
 
 var linter = require('../linterInterface');
 
-var _require2 = require('../helpers'),
-    createPoint = _require2.createPoint,
-    createRange = _require2.createRange;
+var _require2 = require('../atomInterface'),
+    addErrorNotification = _require2.addErrorNotification;
+
+var _require3 = require('../helpers'),
+    createPoint = _require3.createPoint,
+    createRange = _require3.createRange;
 
 var errorLine = function errorLine(error) {
   return error.loc.start ? error.loc.start.line : error.loc.line;
@@ -44,6 +47,15 @@ var setErrorMessageInLinter = function setErrorMessageInLinter(_ref) {
   }]);
 };
 
-var handleError = _.flow(setErrorMessageInLinter, _.stubFalse);
+var isSyntaxError = _.overSome([_.flow(_.get('error.loc.start.line'), _.isInteger), _.flow(_.get('error.loc.line'), _.isInteger)]);
+
+var displayErrorInPopup = function displayErrorInPopup(args) {
+  return addErrorNotification('prettier-atom failed: ' + args.error.message, {
+    stack: args.error.stack,
+    dismissable: true
+  });
+};
+
+var handleError = _.cond([[isSyntaxError, setErrorMessageInLinter], [_.stubTrue, displayErrorInPopup]]);
 
 module.exports = handleError;

--- a/src/executePrettier/handleError.test.js
+++ b/src/executePrettier/handleError.test.js
@@ -1,8 +1,10 @@
 jest.mock('../editorInterface');
 jest.mock('../linterInterface');
+jest.mock('../atomInterface');
 
 const { getCurrentFilePath } = require('../editorInterface');
 const linterInterface = require('../linterInterface');
+const { addErrorNotification } = require('../atomInterface');
 const { createRange } = require('../helpers');
 const handleError = require('./handleError');
 
@@ -86,4 +88,12 @@ describe('position property of the message sent to the linter', () => {
     const expectedPosition = createRange([2, 100], [2, 100]);
     expect(positionOfFirstCallOfFirstMessageOfSetMessages()).toEqual(expectedPosition);
   });
+});
+
+it('displays errors in a popup if they are not syntax errors', () => {
+  const error = new Error('fake error');
+
+  handleError({ error });
+
+  expect(addErrorNotification).toHaveBeenCalled();
 });


### PR DESCRIPTION
Previously, we were assuming all errors thrown during execution of the formatters were going to be
syntax errors. However, this is not the case, so we must handle these errors elegantly by displaying
them in a popup.

Resolves #231