### PR TITLE
Add eslint-plugin-prettier to formatOnSave list 

### DIFF
--- a/src/formatOnSave/isPrettierInPackageJson.js
+++ b/src/formatOnSave/isPrettierInPackageJson.js
@@ -27,7 +27,11 @@ const isPrettierInPackageJson: (editor: TextEditor) => boolean = _.flow(
 
 const isPrettierEslintInPackageJson: (editor: TextEditor) => boolean = _.flow(
   readContentsOfNearestPackageJson,
-  _.overSome([hasPackage('prettier-eslint'), hasPackage('prettier-eslint-cli')]),
+  _.overSome([
+    hasPackage('prettier-eslint'), 
+    hasPackage('prettier-eslint-cli'),
+    hasPackage('eslint-plugin-prettier'),
+  ]),
 );
 
 module.exports = _.cond([

--- a/src/formatOnSave/isPrettierInPackageJson.test.js
+++ b/src/formatOnSave/isPrettierInPackageJson.test.js
@@ -89,6 +89,16 @@ describe('when shouldUseEslint is true', () => {
 
     expect(actual).toBe(true);
   });
+  
+  it('is true if eslint-plugin-prettier is a dev dependency', () => {
+    readPkgUp.sync.mockImplementation(() => ({
+      pkg: { devDependencies: { 'eslint-plugin-prettier': '^0.0.1' } },
+    }));
+
+    const actual = isPrettierInPackageJson();
+
+    expect(actual).toBe(true);
+  });
 
   it('is false if neither prettier-eslint nor prettier-eslint-cli are dependencies', () => {
     const actual = isPrettierInPackageJson();


### PR DESCRIPTION
Relying only on `prettier-eslint` and `prettier-eslint-cli` skips a good chunk of applications using prettier, using eslint, but not using one of those manual packages. `eslint-plugin-prettier` should be a good package to also look for to see if prettier is enabled and integrated.