### PR TITLE
fix(statusTile): Fix style scope

### DIFF
--- a/styles/statusTile.less
+++ b/styles/statusTile.less
@@ -4,11 +4,12 @@ div {
     display: none;
   }
 
-  &:hover {
+  // Show the tile as clickable.
+  &.prettier-status-tile:hover {
     text-decoration: underline;
     cursor: pointer;
   }
-  
+
   // If Format on Save is enabled, make the label more visible.
   &[data-prettier-format-on-save="enabled"] {
     color: #8BC34A;


### PR DESCRIPTION
Style was previously applied to every div in Atom.

@robwise Sorry for bailing out lately! I was a bit overwhelmed at work and didn't want to do more of the same at home.
I'm back to reading issues and trying to get up to speed though!