### PR TITLE
fix(display-of-errors): show syntax errors for unsaved files

### DIFF
--- a/dist/executePrettier/handleError.js
+++ b/dist/executePrettier/handleError.js
@@ -49,6 +49,8 @@ var setErrorMessageInLinter = function setErrorMessageInLinter(_ref) {
 
 var isSyntaxError = _.overSome([_.flow(_.get('error.loc.start.line'), _.isInteger), _.flow(_.get('error.loc.line'), _.isInteger)]);
 
+var isFilePathPresent = _.flow(_.get('editor'), getCurrentFilePath, _.negate(_.isNil));
+
 var displayErrorInPopup = function displayErrorInPopup(args) {
   return addErrorNotification('prettier-atom failed: ' + args.error.message, {
     stack: args.error.stack,
@@ -56,6 +58,6 @@ var displayErrorInPopup = function displayErrorInPopup(args) {
   });
 };
 
-var handleError = _.cond([[isSyntaxError, setErrorMessageInLinter], [_.stubTrue, displayErrorInPopup]]);
+var handleError = _.flow(_.cond([[_.overEvery([isSyntaxError, isFilePathPresent]), setErrorMessageInLinter], [_.stubTrue, displayErrorInPopup]]));
 
 module.exports = handleError;

--- a/src/executePrettier/handleError.js
+++ b/src/executePrettier/handleError.js
@@ -46,15 +46,23 @@ const isSyntaxError: HandleErrorArgs => boolean = _.overSome([
   _.flow(_.get('error.loc.line'), _.isInteger),
 ]);
 
+const isFilePathPresent: HandleErrorArgs => boolean = _.flow(
+  _.get('editor'),
+  getCurrentFilePath,
+  _.negate(_.isNil),
+);
+
 const displayErrorInPopup = (args: HandleErrorArgs) =>
   addErrorNotification(`prettier-atom failed: ${args.error.message}`, {
     stack: args.error.stack,
     dismissable: true,
   });
 
-const handleError: HandleErrorArgs => void = _.cond([
-  [isSyntaxError, setErrorMessageInLinter],
-  [_.stubTrue, displayErrorInPopup],
-]);
+const handleError: HandleErrorArgs => void = _.flow(
+  _.cond([
+    [_.overEvery([isSyntaxError, isFilePathPresent]), setErrorMessageInLinter],
+    [_.stubTrue, displayErrorInPopup],
+  ]),
+);
 
 module.exports = handleError;

--- a/src/executePrettier/handleError.test.js
+++ b/src/executePrettier/handleError.test.js
@@ -68,6 +68,7 @@ it('works with the alternative error location API from Prettier', () => {
 
 describe('position property of the message sent to the linter', () => {
   it('accounts for the start row of the buffer range', () => {
+    getCurrentFilePath.mockImplementation(() => 'fake/file/path.js');
     const editor = null;
     const bufferRange = { start: { row: 3, column: 99 }, end: { row: 99, column: 99 } };
     const error = buildFakeError({ line: 1, column: 2 });
@@ -79,6 +80,7 @@ describe('position property of the message sent to the linter', () => {
   });
 
   it('accounts for the start column of the buffer range if the error line is the first line', () => {
+    getCurrentFilePath.mockImplementation(() => 'fake/file/path.js');
     const editor = null;
     const bufferRange = { start: { row: 3, column: 99 }, end: { row: 99, column: 99 } };
     const error = buildFakeError({ line: 0, column: 2 });
@@ -91,6 +93,16 @@ describe('position property of the message sent to the linter', () => {
 });
 
 it('displays errors in a popup if they are not syntax errors', () => {
+  getCurrentFilePath.mockImplementation(() => 'fake/file/path.js');
+  const error = new Error('fake error');
+
+  handleError({ error });
+
+  expect(addErrorNotification).toHaveBeenCalled();
+});
+
+it('displays errors in a popup if there is no filepath (linter requires a filepath)', () => {
+  getCurrentFilePath.mockImplementation(() => null);
   const error = new Error('fake error');
 
   handleError({ error });


### PR DESCRIPTION
Previously we were simply exiting early during the error handling process if there was no filepath
because the linter package requires a filepath in order to work. Now, we detect this early and
instead send the error message to a popup so that the user still gets some feedback.

See: https://github.com/steelbrain/linter/issues/1235

Fixes #235