### PR TITLE
feat(error-logging): log errors to Atom's developer tools

### DIFF
--- a/dist/atomInterface/index.js
+++ b/dist/atomInterface/index.js
@@ -129,6 +129,7 @@ var attemptWithErrorNotification = function attemptWithErrorNotification(func) {
   try {
     func.apply(undefined, args);
   } catch (e) {
+    console.error(e); // eslint-disable-line no-console
     addErrorNotification(e.message, { dismissable: true, stack: e.stack });
   }
 };

--- a/dist/executePrettier/handleError.js
+++ b/dist/executePrettier/handleError.js
@@ -52,7 +52,8 @@ var isSyntaxError = _.overSome([_.flow(_.get('error.loc.start.line'), _.isIntege
 var isFilePathPresent = _.flow(_.get('editor'), getCurrentFilePath, _.negate(_.isNil));
 
 var displayErrorInPopup = function displayErrorInPopup(args) {
-  return addErrorNotification('prettier-atom failed: ' + args.error.message, {
+  return console.error(args.error) || // eslint-disable-line no-console
+  addErrorNotification('prettier-atom failed: ' + args.error.message, {
     stack: args.error.stack,
     dismissable: true
   });

--- a/dist/linterInterface/index.js
+++ b/dist/linterInterface/index.js
@@ -19,7 +19,12 @@ var get = function get() {
 
 var setMessages = function setMessages(editor, messages) {
   var filePath = getCurrentFilePath(editor);
-  if (!indieDelegate || !filePath) return;
+
+  if (!indieDelegate || !filePath) {
+    // eslint-disable-next-line
+    console.error('prettier-atom attempted to set messages with linter package, but was unable. Messages: ' + JSON.stringify(messages));
+    return;
+  }
 
   indieDelegate.setMessages(filePath, messages);
 };

--- a/dist/main.js
+++ b/dist/main.js
@@ -59,7 +59,7 @@ var lazyDisplayDebugInfo = function lazyDisplayDebugInfo() {
 
 var lazyToggleFormatOnSave = function lazyToggleFormatOnSave() {
   if (!toggleFormatOnSave) {
-    // eslint-disable-next-line global-require
+    // eslint-disable-next-line global-require prefer-destructuring
     toggleFormatOnSave = require('./atomInterface').toggleFormatOnSave;
   }
   toggleFormatOnSave();

--- a/src/atomInterface/index.js
+++ b/src/atomInterface/index.js
@@ -81,6 +81,7 @@ const attemptWithErrorNotification = (func: Function, ...args: Array<any>) => {
   try {
     func(...args);
   } catch (e) {
+    console.error(e); // eslint-disable-line no-console
     addErrorNotification(e.message, { dismissable: true, stack: e.stack });
   }
 };

--- a/src/executePrettier/handleError.js
+++ b/src/executePrettier/handleError.js
@@ -53,6 +53,7 @@ const isFilePathPresent: HandleErrorArgs => boolean = _.flow(
 );
 
 const displayErrorInPopup = (args: HandleErrorArgs) =>
+  console.error(args.error) || // eslint-disable-line no-console
   addErrorNotification(`prettier-atom failed: ${args.error.message}`, {
     stack: args.error.stack,
     dismissable: true,

--- a/src/executePrettier/handleError.test.js
+++ b/src/executePrettier/handleError.test.js
@@ -23,6 +23,17 @@ const buildFakeError = ({ line, column }, useAlternativeErrorApi = false) => {
 const positionOfFirstCallOfFirstMessageOfSetMessages = () =>
   linterInterface.setMessages.mock.calls[0][1][0].location.position;
 
+let originalConsoleError;
+
+beforeEach(() => {
+  originalConsoleError = console.error; // eslint-disable-line no-console
+  console.error = jest.fn(); // eslint-disable-line no-console
+});
+
+afterEach(() => {
+  console.error = originalConsoleError; // eslint-disable-line no-console
+});
+
 // tests
 it('sets an error message in the indie-linter', () => {
   getCurrentFilePath.mockImplementation(() => '/fake/file/path.js');
@@ -99,6 +110,7 @@ it('displays errors in a popup if they are not syntax errors', () => {
   handleError({ error });
 
   expect(addErrorNotification).toHaveBeenCalled();
+  expect(console.error).toHaveBeenCalledWith(error); // eslint-disable-line no-console
 });
 
 it('displays errors in a popup if there is no filepath (linter requires a filepath)', () => {
@@ -108,4 +120,5 @@ it('displays errors in a popup if there is no filepath (linter requires a filepa
   handleError({ error });
 
   expect(addErrorNotification).toHaveBeenCalled();
+  expect(console.error).toHaveBeenCalledWith(error); // eslint-disable-line no-console
 });

--- a/src/formatOnSave/index.test.js
+++ b/src/formatOnSave/index.test.js
@@ -52,6 +52,8 @@ it('does nothing if it should not format on save', () => {
 });
 
 it('catches uncaught errors so that the user is not prevented from saving', () => {
+  const originalConsoleError = console.error; // eslint-disable-line no-console
+  console.error = jest.fn(); // eslint-disable-line no-console
   const editor = createMockTextEditor();
   const fakeError = new Error('fake error');
   atom = { notifications: { addError: jest.fn() } };
@@ -62,4 +64,7 @@ it('catches uncaught errors so that the user is not prevented from saving', () =
   formatOnSave(editor);
 
   expect(atom.notifications.addError).toHaveBeenCalled();
+  expect(console.error).toHaveBeenCalledWith(fakeError); // eslint-disable-line no-console
+
+  console.error = originalConsoleError; // eslint-disable-line no-console
 });

--- a/src/linterInterface/index.js
+++ b/src/linterInterface/index.js
@@ -13,7 +13,16 @@ const get = () => indieDelegate;
 
 const setMessages = (editor: TextEditor, messages: Array<Linter$Message>) => {
   const filePath = getCurrentFilePath(editor);
-  if (!indieDelegate || !filePath) return;
+
+  if (!indieDelegate || !filePath) {
+    // eslint-disable-next-line
+    console.error(
+      `prettier-atom attempted to set messages with linter package, but was unable. Messages: ${JSON.stringify(
+        messages,
+      )}`,
+    );
+    return;
+  }
 
   indieDelegate.setMessages(filePath, messages);
 };


### PR DESCRIPTION
We were either using the linter package or an in-app popup to display errors, but now we also will
log the error to the console for closer inspection.