### PR TITLE
Process postcss files!

### DIFF
--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -76,7 +76,7 @@
         "description":
           "Select which files containing CSS should be formatted.<br>Use `Editor: Log Cursor Scope` to determine the scopes for a file.",
         "type": "array",
-        "default": ["source.css", "source.less", "source.css.less", "source.scss", "source.css.scss"],
+        "default": ["source.css", "source.less", "source.css.less", "source.scss", "source.css.scss", "source.css.postcss"],
         "items": {
           "type": "string"
         },


### PR DESCRIPTION
Postcss is a popular and common css processor/syntax, this change makes it such that prettier-atom lints postcss files by default :sparkles:

Ref #183