### PR TITLE
test(executePrettier): Add test for setTextViaDiff usage

### DIFF
--- a/src/executePrettier/executePrettierOnBufferRange.js
+++ b/src/executePrettier/executePrettierOnBufferRange.js
@@ -36,6 +36,8 @@ const executePrettierOnBufferRange = (editor: TextEditor, bufferRange: Range) =>
     return;
   }
 
+  // we use setTextViaDiff when formatting the entire buffer to improve performance,
+  // maintain metadata (bookmarks, folds, etc) and eliminate syntax highlight flickering
   const editorBuffer = editor.getBuffer();
   if (editorBuffer.getRange().isEqual(bufferRange)) {
     editorBuffer.setTextViaDiff(transformed);

--- a/src/executePrettier/executePrettierOnBufferRange.test.js
+++ b/src/executePrettier/executePrettierOnBufferRange.test.js
@@ -36,6 +36,19 @@ it('sets the transformed text in the buffer range', () => {
   expect(editor.setTextInBufferRange).toHaveBeenCalledWith(bufferRangeFixture, 'const foo = 2;');
 });
 
+it('sets the transformed text via diff when buffer equals entire range of editor', () => {
+  const setTextViaDiffMock = jest.fn();
+  editor.getBuffer.mockImplementation(() => ({
+    getRange: () => ({ isEqual: () => true }),
+    setTextViaDiff: setTextViaDiffMock,
+  }));
+
+  executePrettierOnBufferRange(editor, bufferRangeFixture);
+
+  expect(prettier.format).toHaveBeenCalledWith('const foo = (2);', { useTabs: false });
+  expect(setTextViaDiffMock).toHaveBeenCalledWith('const foo = 2;');
+});
+
 it('runs linter:lint if available to refresh linter highlighting', () => {
   executePrettierOnBufferRange(editor, bufferRangeFixture);
 


### PR DESCRIPTION
This PR adds test coverage for the use of `setTextViaDiff` when formatting the editor's entire buffer. It should resolve #105 and #215.

BTW, I tested the `setTextViaDiff` change on a few large files and I'm seeing a huge speed improvement. For example, edits to https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js on my machine went from taking over 6 seconds to save to less than 1 second.