### PR TITLE
fix(linter): resolve issue with linter not showing error messages properly

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -152,8 +152,8 @@ var consumeStatusBar = function consumeStatusBar(statusBar) {
 
 var consumeIndie = function consumeIndie(registerIndie) {
   var linter = registerIndie({ name: 'Prettier' });
-  subscriptions.add(linter);
   linterInterface.set(linter);
+  subscriptions.add(linter);
 
   // Setting and clearing messages per filePath
   subscriptions.add(atom.workspace.observeTextEditors(function (textEditor) {
@@ -165,7 +165,6 @@ var consumeIndie = function consumeIndie(registerIndie) {
     var subscription = textEditor.onDidDestroy(function () {
       subscriptions.remove(subscription);
       linter.setMessages(editorPath, []);
-      linterInterface.set(null);
     });
     subscriptions.add(subscription);
   }));

--- a/src/main.js
+++ b/src/main.js
@@ -146,8 +146,8 @@ const consumeStatusBar = statusBar => {
 
 const consumeIndie = registerIndie => {
   const linter = registerIndie({ name: 'Prettier' });
-  subscriptions.add(linter);
   linterInterface.set(linter);
+  subscriptions.add(linter);
 
   // Setting and clearing messages per filePath
   subscriptions.add(
@@ -160,7 +160,6 @@ const consumeIndie = registerIndie => {
       const subscription = textEditor.onDidDestroy(() => {
         subscriptions.remove(subscription);
         linter.setMessages(editorPath, []);
-        linterInterface.set(null);
       });
       subscriptions.add(subscription);
     }),


### PR DESCRIPTION
In some cases, the IndieLinter was `null` when it shouldn't have been. This was due to setting it
null when changing TextEditor objects, which was unnecessary and should not have been done. This
stops doing that so that there is always and IndieLinter available and thus we are always able to
properly set linter messages.

fix #318, #298, #235 