### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,22 @@
 *.js text eol=lf
 flow-typed/npm/* linguist-generated
 dist/* linguist-generated
+
+/.github export-ignore
+/tests export-ignore
+/.all-contributorsrc export-ignore
+/.babelrc export-ignore
+/.eslintignore export-ignore
+/.eslintrc.yml export-ignore
+/.flowconfig export-ignore
+/.gitignore export-ignore
+/.nvmrc export-ignore
+/.prettierignore export-ignore
+/.prettierrc export-ignore
+/.travis.yml export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md export-ignore
+/package-scripts.yml export-ignore
+/prettier-demo.gif export-ignore
+/prettier-eslint-demo.gif export-ignore
+/yarn.lock export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc).
