### PR TITLE
fix(prettier-eslint): lock to 8.6.2 to avoid regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.17.4",
     "loophole": "^1.1.0",
     "prettier": "1.10.2",
-    "prettier-eslint": "^8.7.0",
+    "prettier-eslint": "8.6.2",
     "prettier-stylelint": "^0.4.2",
     "read-pkg-up": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4741,7 +4741,24 @@ prettier-eslint-cli@^4.7.0:
     rxjs "^5.3.0"
     yargs "10.0.3"
 
-prettier-eslint@^8.5.0, prettier-eslint@^8.7.0:
+prettier-eslint@8.6.2:
+  version "8.6.2"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.6.2.tgz#aebaab317e5361fd9f558230c5c0b028ab11badd"
+  dependencies:
+    babel-runtime "^6.26.0"
+    common-tags "^1.4.0"
+    dlv "^1.1.0"
+    eslint "^4.0.0"
+    indent-string "^3.2.0"
+    lodash.merge "^4.6.0"
+    loglevel-colored-level-prefix "^1.0.0"
+    prettier "^1.7.0"
+    pretty-format "^22.0.3"
+    require-relative "^0.8.7"
+    typescript "^2.5.1"
+    typescript-eslint-parser "^11.0.0"
+
+prettier-eslint@^8.5.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.7.0.tgz#c54ce5affee129674958bd40a7899f97128c975a"
   dependencies:


### PR DESCRIPTION
We are experiencing interrupted behavior due to regressions in prettier-eslint. We are locking the
bundled version down to a known good configuration.