### PR TITLE
fix(prettier-eslint): lock version to 8.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.17.4",
     "loophole": "^1.1.0",
     "prettier": "1.10.2",
-    "prettier-eslint": "8.6.2",
+    "prettier-eslint": "8.4.0",
     "prettier-stylelint": "^0.4.2",
     "read-pkg-up": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4741,18 +4741,17 @@ prettier-eslint-cli@^4.7.0:
     rxjs "^5.3.0"
     yargs "10.0.3"
 
-prettier-eslint@8.6.2:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.6.2.tgz#aebaab317e5361fd9f558230c5c0b028ab11badd"
+prettier-eslint@8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.4.0.tgz#ec947053f558833139f470e1bb7ea0722efc3d26"
   dependencies:
-    babel-runtime "^6.26.0"
     common-tags "^1.4.0"
     dlv "^1.1.0"
-    eslint "^4.0.0"
+    eslint "^4.5.0"
     indent-string "^3.2.0"
     lodash.merge "^4.6.0"
     loglevel-colored-level-prefix "^1.0.0"
-    prettier "^1.7.0"
+    prettier "^1.9.0"
     pretty-format "^22.0.3"
     require-relative "^0.8.7"
     typescript "^2.5.1"
@@ -4794,7 +4793,7 @@ prettier-stylelint@^0.4.2:
     tempy "^0.2.1"
     update-notifier "^2.2.0"
 
-prettier@1.10.2:
+prettier@1.10.2, prettier@^1.9.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 


### PR DESCRIPTION
Some users were saying that we needed to rollback even further to 8.4.0