### PR TITLE
fix(executePrettier): adjust for API inconsistencies + add type coverage

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,3 +22,4 @@ rules:
   no-mixed-operators: 0 # incompatible with prettier
   no-confusing-arrow: 0 # incompatible with prettier
   max-len: 0 # prefer prettier
+  prefer-destructuring: 0 # not always preferable

--- a/dist/executePrettier/executePrettierOnBufferRange.js
+++ b/dist/executePrettier/executePrettierOnBufferRange.js
@@ -93,7 +93,7 @@ var executePrettierOrIntegration = function () {
             // TODO: remove this try/catch once Prettier.formatWithCursor stabilizes
 
             try {
-              formatted = executePrettierWithCursor(editor, text, cursorOffset);
+              formatted = executePrettierWithCursor(editor, text, cursorOffset).formatted;
             } catch (error) {
               formatted = executePrettier(editor, text);
             }

--- a/src/executePrettier/executePrettierOnBufferRange.js
+++ b/src/executePrettier/executePrettierOnBufferRange.js
@@ -31,7 +31,11 @@ const executePrettierEslint = (editor: TextEditor, text: string): string =>
 const executePrettierStylelint = (editor: TextEditor, text: string): string =>
   prettierStylelint.format(buildPrettierStylelintOptions(editor, text));
 
-const executePrettierOrIntegration = async (editor: TextEditor, text: string, cursorOffset: number) => {
+const executePrettierOrIntegration = async (
+  editor: TextEditor,
+  text: string,
+  cursorOffset: number,
+): Promise<{ formatted: string, cursorOffset: number }> => {
   if (shouldUseStylelint() && isCurrentScopeCssScope(editor)) {
     // TODO: add support for cursor position - https://github.com/hugomrdias/prettier-stylelint/issues/13
     const formatted = await executePrettierStylelint(editor, text);
@@ -46,11 +50,11 @@ const executePrettierOrIntegration = async (editor: TextEditor, text: string, cu
     return { formatted, cursorOffset };
   }
 
-  let formatted;
+  let formatted: string;
 
   // TODO: remove this try/catch once Prettier.formatWithCursor stabilizes
   try {
-    formatted = executePrettierWithCursor(editor, text, cursorOffset);
+    formatted = executePrettierWithCursor(editor, text, cursorOffset).formatted;
   } catch (error) {
     formatted = executePrettier(editor, text);
   }


### PR DESCRIPTION
A lack of type coverage lead to an accidental bug. Added type coverage to prevent this from happening again. 👍 

fixes #364 