### PR TITLE
Fix formatOnSave bug with eslintignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 coverage
 .opt-in
 .opt-out
+yarn-error.log

--- a/dist/formatOnSave/shouldFormatOnSave.js
+++ b/dist/formatOnSave/shouldFormatOnSave.js
@@ -16,9 +16,10 @@ var _require3 = require('../atomInterface'),
     getExcludedGlobs = _require3.getExcludedGlobs,
     getWhitelistedGlobs = _require3.getWhitelistedGlobs,
     isDisabledIfNotInPackageJson = _require3.isDisabledIfNotInPackageJson,
-    isDisabledIfNoConfigFile = _require3.isDisabledIfNoConfigFile;
+    isDisabledIfNoConfigFile = _require3.isDisabledIfNoConfigFile,
+    shouldRespectEslintignore = _require3.shouldRespectEslintignore;
 
-var isFilePathEslintignored = require('./isFilePathEslintIgnored');
+var isFilePathEslintIgnored = require('./isFilePathEslintIgnored');
 var isFilePathPrettierIgnored = require('./isFilePathPrettierIgnored');
 var isPrettierInPackageJson = require('./isPrettierInPackageJson');
 
@@ -40,8 +41,7 @@ var noWhitelistGlobsPresent = _.flow(getWhitelistedGlobs, _.isEmpty);
 var isFilePathWhitelisted = _.flow(getCurrentFilePath, function (filePath) {
   return someGlobsMatchFilePath(getWhitelistedGlobs(), filePath);
 });
-
-var isFilePathNotEslintignored = _.flow(getCurrentFilePath, _.negate(isFilePathEslintignored));
+var isEslintIgnored = _.flow(getCurrentFilePath, isFilePathEslintIgnored);
 
 var isFilePathNotPrettierIgnored = _.flow(getCurrentFilePath, _.negate(isFilePathPrettierIgnored));
 
@@ -53,6 +53,6 @@ var isPrettierConfigPresent = function isPrettierConfigPresent(editor
   _.flow(getCurrentFilePath, getPrettierInstance(editor).resolveConfig.sync, _.negate(_.isNil))(editor);
 };
 
-var shouldFormatOnSave = _.overEvery([isFormatOnSaveEnabled, hasFilePath, isInScope, _.overSome([isFilePathWhitelisted, _.overEvery([noWhitelistGlobsPresent, filePathDoesNotMatchBlacklistGlobs])]), isFilePathNotEslintignored, isFilePathNotPrettierIgnored, _.overSome([_.negate(isDisabledIfNotInPackageJson), isPrettierInPackageJson]), _.overSome([_.negate(isDisabledIfNoConfigFile), isPrettierConfigPresent])]);
+var shouldFormatOnSave = _.overEvery([isFormatOnSaveEnabled, hasFilePath, isInScope, _.overSome([isFilePathWhitelisted, _.overEvery([noWhitelistGlobsPresent, filePathDoesNotMatchBlacklistGlobs])]), _.overSome([_.negate(shouldRespectEslintignore), _.negate(isEslintIgnored)]), isFilePathNotPrettierIgnored, _.overSome([_.negate(isDisabledIfNotInPackageJson), isPrettierInPackageJson]), _.overSome([_.negate(isDisabledIfNoConfigFile), isPrettierConfigPresent])]);
 
 module.exports = shouldFormatOnSave;

--- a/src/editorInterface/index.js
+++ b/src/editorInterface/index.js
@@ -42,7 +42,7 @@ const isCurrentScopeMarkdownScope = (editor: TextEditor) =>
 
 const isCurrentScopeVueScope = (editor: TextEditor) => getVueScopes().includes(getCurrentScope(editor));
 
-const getCurrentFilePath = (editor: TextEditor) =>
+const getCurrentFilePath: (editor: TextEditor) => ?FilePath = editor =>
   editor.buffer.file ? editor.buffer.file.getPath() : undefined;
 
 const getCurrentDir: (editor: TextEditor) => ?string = editor =>

--- a/src/formatOnSave/isFilePathEslintIgnored.js
+++ b/src/formatOnSave/isFilePathEslintIgnored.js
@@ -26,7 +26,7 @@ const getIgnoredGlobsFromNearestEslintIgnore: (filePath: FilePath) => Globs = _.
   getLinesFromFilePath,
 );
 
-const isFilePathEslintignored: (filePath: FilePath) => boolean = _.flow(
+const isFilePathEslintignored: (filePath: ?FilePath) => boolean = _.flow(
   _.over([getIgnoredGlobsFromNearestEslintIgnore, getFilePathRelativeToEslintignore]),
   _.spread(someGlobsMatchFilePath),
 );

--- a/src/formatOnSave/shouldFormatOnSave.test.js
+++ b/src/formatOnSave/shouldFormatOnSave.test.js
@@ -13,6 +13,7 @@ const {
   getExcludedGlobs,
   getWhitelistedGlobs,
   getAllScopes,
+  shouldRespectEslintignore,
 } = require('../atomInterface');
 const getPrettierInstance = require('../helpers/getPrettierInstance');
 const { getCurrentScope, getCurrentFilePath } = require('../editorInterface');
@@ -89,12 +90,31 @@ it('returns false if the filepath is not in scope', () => {
   expect(actual).toBe(false);
 });
 
-it('returns false if the filepath is eslintignored', () => {
+it('returns false if the filepath is eslintignored and eslintignore should be respected', () => {
+  shouldRespectEslintignore.mockImplementation(() => true);
   isFilePathEslintIgnored.mockImplementation(() => true);
 
   const actual = callShouldFormatOnSave();
 
   expect(actual).toBe(false);
+});
+
+it('returns true if the filepath is eslintignored but eslintignore should _not_ be respected', () => {
+  shouldRespectEslintignore.mockImplementation(() => false);
+  isFilePathEslintIgnored.mockImplementation(() => true);
+
+  const actual = callShouldFormatOnSave();
+
+  expect(actual).toBe(true);
+});
+
+it('returns true if the filepath is not eslintignored', () => {
+  shouldRespectEslintignore.mockImplementation(() => true);
+  isFilePathEslintIgnored.mockImplementation(() => false);
+
+  const actual = callShouldFormatOnSave();
+
+  expect(actual).toBe(true);
 });
 
 it('returns false if the filepath is prettier ignored', () => {


### PR DESCRIPTION
- check "shouldRespectEslintignore" setting prior to checking whether
  the filepath should be eslintignore'd
- add tests for
  : should respect and is eslintignored
  : should not respect and is eslintignored
  : is not eslintignored

fixes #347