### PR TITLE
Fallback to global instance of prettier before falling back to a bundled one

### DIFF
--- a/dist/displayDebugInfo/index.js
+++ b/dist/displayDebugInfo/index.js
@@ -14,6 +14,9 @@ var _require = require('../atomInterface'),
     getPrettierAtomConfig = _require.getPrettierAtomConfig,
     addInfoNotification = _require.addInfoNotification;
 
+var _require2 = require('../helpers/getPrettierPath'),
+    getGlobalPrettierPath = _require2.getGlobalPrettierPath;
+
 var getDepPath = function getDepPath(dep) {
   return path.join(__dirname, '..', '..', 'node_modules', dep);
 };
@@ -23,7 +26,8 @@ var getPackageInfo = function getPackageInfo(dir) {
 };
 
 var getDebugInfo = function getDebugInfo() {
-  return ('\nAtom version: ' + getAtomVersion() + '\nprettier-atom version: ' + getPackageInfo(__dirname).version + '\nprettier version: ' + getPackageInfo(getDepPath('prettier')).version + '\nprettier-eslint version: ' + getPackageInfo(getDepPath('prettier-eslint')).version + '\nprettier-atom configuration: ' + (0, _stringify2.default)(getPrettierAtomConfig(), null, 2) + '\n').trim();
+  var globalPrettierPath = getGlobalPrettierPath();
+  return ('\nAtom version: ' + getAtomVersion() + '\nprettier-atom version: ' + getPackageInfo(__dirname).version + '\nprettier: ' + (globalPrettierPath || 'bundled') + '\nprettier version: ' + getPackageInfo(globalPrettierPath || getDepPath('prettier')).version + '\nprettier-eslint version: ' + getPackageInfo(getDepPath('prettier-eslint')).version + '\nprettier-atom configuration: ' + (0, _stringify2.default)(getPrettierAtomConfig(), null, 2) + '\n').trim();
 };
 
 var displayDebugInfo = function displayDebugInfo() {

--- a/dist/helpers/getPrettierInstance.js
+++ b/dist/helpers/getPrettierInstance.js
@@ -6,28 +6,22 @@ var bundledPrettier = require('prettier');
 var _require = require('../editorInterface'),
     getCurrentFilePath = _require.getCurrentFilePath;
 
-var _require2 = require('./general'),
-    findCachedFromFilePath = _require2.findCachedFromFilePath;
-
-var path = require('path');
-
-var PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js');
-
-var getLocalPrettierPath = function getLocalPrettierPath(filePath) {
-  return findCachedFromFilePath(filePath, PRETTIER_INDEX_PATH);
-};
+var _require2 = require('./getPrettierPath'),
+    getLocalOrGlobalPrettierPath = _require2.getLocalOrGlobalPrettierPath;
 
 // charypar: This is currently the best way to use local prettier instance.
 // Using the CLI introduces a noticeable delay and there is currently no
 // way to use prettier as a long-running process for formatting files as needed
 //
 // See https://github.com/prettier/prettier/issues/918
+
+
 var requireWithFallbackToBundledPrettier = function requireWithFallbackToBundledPrettier(prettierPackagePath
 // $$FlowFixMe
 ) {
   return prettierPackagePath ? require(prettierPackagePath) : bundledPrettier;
 }; // eslint-disable-line
 
-var getPrettierInstance = _.flow(getCurrentFilePath, getLocalPrettierPath, requireWithFallbackToBundledPrettier);
+var getPrettierInstance = _.flow(getCurrentFilePath, getLocalOrGlobalPrettierPath, requireWithFallbackToBundledPrettier);
 
 module.exports = getPrettierInstance;

--- a/dist/helpers/getPrettierPath.js
+++ b/dist/helpers/getPrettierPath.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var _require = require('./general'),
+    findCachedFromFilePath = _require.findCachedFromFilePath;
+
+var path = require('path');
+
+var _require2 = require('atom-linter'),
+    findCached = _require2.findCached;
+
+var globalModules = require('global-modules');
+var yarnGlobalModules = require('yarn-global-modules')();
+
+var PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js');
+
+var getGlobalPrettierPath = function getGlobalPrettierPath() {
+  return findCached(globalModules, PRETTIER_INDEX_PATH) || findCached(yarnGlobalModules, PRETTIER_INDEX_PATH);
+};
+
+var getLocalPrettierPath = function getLocalPrettierPath(filePath) {
+  return findCachedFromFilePath(filePath, PRETTIER_INDEX_PATH);
+};
+
+var getLocalOrGlobalPrettierPath = function getLocalOrGlobalPrettierPath(filePath) {
+  return getLocalPrettierPath(filePath) || getGlobalPrettierPath();
+};
+
+module.exports = {
+  getGlobalPrettierPath: getGlobalPrettierPath,
+  getLocalPrettierPath: getLocalPrettierPath,
+  getLocalOrGlobalPrettierPath: getLocalOrGlobalPrettierPath
+};

--- a/package-scripts.yml
+++ b/package-scripts.yml
@@ -84,5 +84,5 @@ scripts:
     script: |
       dirty=`git status -s | grep -v '^??' | wc -l | awk '{print $1}'`
       echo Found $dirty dirty files. These need to be committed to pass CI.
-      [ "$dirty" != "0" ] && exit 1
+      [ "$dirty" != "0" ] && git diff && exit 1
       exit 0

--- a/package.json
+++ b/package.json
@@ -25,13 +25,15 @@
     "babel-runtime": "^6.26.0",
     "editorconfig": "^0.15.0",
     "editorconfig-to-prettier": "^0.0.6",
+    "global-modules": "^1.0.0",
     "ignore": "^3.3.7",
     "lodash": "^4.17.5",
     "loophole": "^1.1.0",
     "prettier": "1.11.1",
     "prettier-eslint": "^8.8.1",
     "prettier-stylelint": "^0.4.2",
-    "read-pkg-up": "^3.0.0"
+    "read-pkg-up": "^3.0.0",
+    "yarn-global-modules": "^1.0.1"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.11.1",

--- a/src/displayDebugInfo/__snapshots__/index.test.js.snap
+++ b/src/displayDebugInfo/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`it displays a notification on Atom with package information 1`] = `
 "Atom version: FAKE_ATOM_VERSION
 prettier-atom version: FAKE_PACKAGE_VERSION
+prettier: FAKE_PRETTIER_PATH
 prettier version: FAKE_PACKAGE_VERSION
 prettier-eslint version: FAKE_PACKAGE_VERSION
 prettier-atom configuration: \\"FAKE_PRETTIER_ATOM_CONFIG\\""

--- a/src/displayDebugInfo/index.js
+++ b/src/displayDebugInfo/index.js
@@ -2,19 +2,23 @@
 const readPkgUp = require('read-pkg-up');
 const path = require('path');
 const { getAtomVersion, getPrettierAtomConfig, addInfoNotification } = require('../atomInterface');
+const { getGlobalPrettierPath } = require('../helpers/getPrettierPath');
 
 const getDepPath = (dep: string) => path.join(__dirname, '..', '..', 'node_modules', dep);
 
 const getPackageInfo = (dir: string) => readPkgUp.sync({ cwd: dir }).pkg;
 
-const getDebugInfo = () =>
-  `
+const getDebugInfo = () => {
+  const globalPrettierPath = getGlobalPrettierPath();
+  return `
 Atom version: ${getAtomVersion()}
 prettier-atom version: ${getPackageInfo(__dirname).version}
-prettier version: ${getPackageInfo(getDepPath('prettier')).version}
+prettier: ${globalPrettierPath || 'bundled'}
+prettier version: ${getPackageInfo(globalPrettierPath || getDepPath('prettier')).version}
 prettier-eslint version: ${getPackageInfo(getDepPath('prettier-eslint')).version}
 prettier-atom configuration: ${JSON.stringify(getPrettierAtomConfig(), null, 2)}
 `.trim();
+};
 
 const displayDebugInfo = () =>
   addInfoNotification('prettier-atom: details on current install', {

--- a/src/displayDebugInfo/index.test.js
+++ b/src/displayDebugInfo/index.test.js
@@ -1,9 +1,11 @@
 jest.mock('read-pkg-up');
 jest.mock('../atomInterface');
+jest.mock('../helpers/getPrettierPath');
 
 const readPkgUp = require('read-pkg-up');
 const displayDebugInfo = require('./index');
 const { getAtomVersion, getPrettierAtomConfig, addInfoNotification } = require('../atomInterface');
+const { getGlobalPrettierPath } = require('../helpers/getPrettierPath');
 
 test('it displays a notification on Atom with package information', () => {
   let title;
@@ -19,6 +21,7 @@ test('it displays a notification on Atom with package information', () => {
   }));
   getAtomVersion.mockImplementation(() => 'FAKE_ATOM_VERSION');
   getPrettierAtomConfig.mockImplementation(() => 'FAKE_PRETTIER_ATOM_CONFIG');
+  getGlobalPrettierPath.mockImplementation(() => 'FAKE_PRETTIER_PATH');
 
   displayDebugInfo();
 

--- a/src/helpers/getPrettierInstance.js
+++ b/src/helpers/getPrettierInstance.js
@@ -2,13 +2,7 @@
 const _ = require('lodash/fp');
 const bundledPrettier = require('prettier');
 const { getCurrentFilePath } = require('../editorInterface');
-const { findCachedFromFilePath } = require('./general');
-const path = require('path');
-
-const PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js');
-
-const getLocalPrettierPath = (filePath: ?FilePath): ?FilePath =>
-  findCachedFromFilePath(filePath, PRETTIER_INDEX_PATH);
+const { getLocalOrGlobalPrettierPath } = require('./getPrettierPath');
 
 // charypar: This is currently the best way to use local prettier instance.
 // Using the CLI introduces a noticeable delay and there is currently no
@@ -21,7 +15,7 @@ const requireWithFallbackToBundledPrettier = (prettierPackagePath: ?string): typ
 
 const getPrettierInstance: (editor: TextEditor) => typeof bundledPrettier = _.flow(
   getCurrentFilePath,
-  getLocalPrettierPath,
+  getLocalOrGlobalPrettierPath,
   requireWithFallbackToBundledPrettier,
 );
 

--- a/src/helpers/getPrettierPath.js
+++ b/src/helpers/getPrettierPath.js
@@ -1,0 +1,24 @@
+// @flow
+
+const { findCachedFromFilePath } = require('./general');
+const path = require('path');
+const { findCached } = require('atom-linter');
+const globalModules = require('global-modules');
+const yarnGlobalModules = require('yarn-global-modules')();
+
+const PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js');
+
+const getGlobalPrettierPath = (): ?FilePath =>
+  findCached(globalModules, PRETTIER_INDEX_PATH) || findCached(yarnGlobalModules, PRETTIER_INDEX_PATH);
+
+const getLocalPrettierPath = (filePath: ?FilePath): ?FilePath =>
+  findCachedFromFilePath(filePath, PRETTIER_INDEX_PATH);
+
+const getLocalOrGlobalPrettierPath = (filePath: ?FilePath): ?FilePath =>
+  getLocalPrettierPath(filePath) || getGlobalPrettierPath();
+
+module.exports = {
+  getGlobalPrettierPath,
+  getLocalPrettierPath,
+  getLocalOrGlobalPrettierPath,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,6 +2270,12 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 expect@^22.4.0:
   version "22.4.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.0.tgz#371edf1ae15b83b5bf5ec34b42f1584660a36c16"
@@ -2697,6 +2703,14 @@ global-modules@^0.2.3:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
 
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
@@ -2705,6 +2719,16 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 globals@^11.0.1:
   version "11.0.1"
@@ -2915,7 +2939,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-homedir-polyfill@^1.0.0:
+homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -3345,6 +3369,10 @@ is-whitespace-character@^1.0.0:
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+
+is-windows@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 is-word-character@^1.0.0:
   version "1.0.1"
@@ -5393,6 +5421,13 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
+resolve-dir@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -6441,15 +6476,15 @@ which@^1.2.12:
   dependencies:
     isexe "^1.1.1"
 
-which@^1.2.9:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+which@^1.2.14, which@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
 
-which@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+which@^1.2.9:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
     isexe "^2.0.0"
 
@@ -6623,3 +6658,15 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yarn-config-directory@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/yarn-config-directory/-/yarn-config-directory-1.0.1.tgz#def1bc82a11e809b98bb429bd2a89aeae91cc3e0"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
+yarn-global-modules@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/yarn-global-modules/-/yarn-global-modules-1.0.1.tgz#be2d96e57e1f31f217eab0ef1b207c25bde37f5d"
+  dependencies:
+    yarn-config-directory "^1.0.0"


### PR DESCRIPTION
The PR partially addresses https://github.com/prettier/prettier-atom/issues/395

The extension now searches for a globally installed prettier if a local one is not found; it falls back to a a bundled instance only if both attempts have failed. This change makes it possible to use [Prettier plugins](https://prettier.io/docs/en/plugins.html) when someone does not want to have any npm modules locally. Please note that Prettier still has issues with [detecting plugins in global installs](https://github.com/prettier/prettier/issues/4000), but I hope it gets fixed soon. IMO it's OK to merge this PR before that happens and simply `npm i -g prettier` once the upstream fix arrives.


cc @olsonpm