### PR TITLE
Follow the UI theme's green color

### DIFF
--- a/styles/statusTile.less
+++ b/styles/statusTile.less
@@ -12,7 +12,7 @@ div {
 
   // If Format on Save is enabled, make the label more visible.
   &[data-prettier-format-on-save='enabled'] {
-    color: #8bc34a;
+    color: @text-color-success;
     &::after {
       content: ' ✓';
     }


### PR DESCRIPTION
Currently prettier-atom is using a hardcoded green color that doesn't follow the success(green) color variable that's documented in Atom's UI styleguide (which is set but the currently used UI theme).

There are 2 ways to use this color, passed as prop via the Less variable or via the `text-success` class.

You should also utilise the Octicons provided from the styleguide instead of the hardcoded `content: ' ✓';` value which you can find in the same file.

_you can view the Styleguidw page by typing Ctrl + Shift + Cmd + G_.