### PR TITLE
Fix usage of babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [["env", { "electron": 1.4 }], "stage-2"],
+  "presets": [["env", { "targets": { "electron": "1.4" } }], "stage-2"],
   "plugins": ["transform-flow-strip-types", "transform-runtime"]
 }

--- a/dist/atomInterface/index.js
+++ b/dist/atomInterface/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
-var _regenerator = require('babel-runtime/regenerator');
-
-var _regenerator2 = _interopRequireDefault(_regenerator);
-
 var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
 
 var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
@@ -11,209 +7,118 @@ var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // constants
-var LINTER_LINT_COMMAND = 'linter:lint';
+const LINTER_LINT_COMMAND = 'linter:lint';
 
 // local helpers
-var getConfigOption = function getConfigOption(key) {
-  return atom.config.get('prettier-atom.' + key);
-};
+const getConfigOption = key => atom.config.get(`prettier-atom.${key}`);
 
-var setConfigOption = function setConfigOption(key, value) {
-  return atom.config.set('prettier-atom.' + key, value);
-};
+const setConfigOption = (key, value) => atom.config.set(`prettier-atom.${key}`, value);
 
-var isLinterLintCommandDefined = function isLinterLintCommandDefined(editor) {
-  return atom.commands.findCommands({ target: atom.views.getView(editor) }).some(function (command) {
-    return command.name === LINTER_LINT_COMMAND;
-  });
-};
+const isLinterLintCommandDefined = editor => atom.commands.findCommands({ target: atom.views.getView(editor) }).some(command => command.name === LINTER_LINT_COMMAND);
 
 // public
-var isLinterEslintAutofixEnabled = function isLinterEslintAutofixEnabled() {
-  return atom.packages.isPackageActive('linter-eslint') && atom.config.get('linter-eslint.fixOnSave');
-};
+const isLinterEslintAutofixEnabled = () => atom.packages.isPackageActive('linter-eslint') && atom.config.get('linter-eslint.fixOnSave');
 
-var shouldUseEslint = function shouldUseEslint() {
-  return getConfigOption('useEslint');
-};
+const shouldUseEslint = () => getConfigOption('useEslint');
 
-var shouldUseStylelint = function shouldUseStylelint() {
-  return getConfigOption('useStylelint');
-};
+const shouldUseStylelint = () => getConfigOption('useStylelint');
 
-var shouldUseEditorConfig = function shouldUseEditorConfig() {
-  return getConfigOption('useEditorConfig');
-};
+const shouldUseEditorConfig = () => getConfigOption('useEditorConfig');
 
-var isFormatOnSaveEnabled = function isFormatOnSaveEnabled() {
-  return getConfigOption('formatOnSaveOptions.enabled');
-};
+const isFormatOnSaveEnabled = () => getConfigOption('formatOnSaveOptions.enabled');
 
-var isDisabledIfNotInPackageJson = function isDisabledIfNotInPackageJson() {
-  return getConfigOption('formatOnSaveOptions.isDisabledIfNotInPackageJson');
-};
+const isDisabledIfNotInPackageJson = () => getConfigOption('formatOnSaveOptions.isDisabledIfNotInPackageJson');
 
-var isDisabledIfNoConfigFile = function isDisabledIfNoConfigFile() {
-  return getConfigOption('formatOnSaveOptions.isDisabledIfNoConfigFile');
-};
+const isDisabledIfNoConfigFile = () => getConfigOption('formatOnSaveOptions.isDisabledIfNoConfigFile');
 
-var shouldRespectEslintignore = function shouldRespectEslintignore() {
-  return getConfigOption('formatOnSaveOptions.respectEslintignore');
-};
+const shouldRespectEslintignore = () => getConfigOption('formatOnSaveOptions.respectEslintignore');
 
-var getJavascriptScopes = function getJavascriptScopes() {
-  return getConfigOption('scopes.javascript');
-};
+const getJavascriptScopes = () => getConfigOption('scopes.javascript');
 
-var getTypescriptScopes = function getTypescriptScopes() {
-  return getConfigOption('scopes.typescript');
-};
+const getTypescriptScopes = () => getConfigOption('scopes.typescript');
 
-var getCssScopes = function getCssScopes() {
-  return getConfigOption('scopes.css');
-};
+const getCssScopes = () => getConfigOption('scopes.css');
 
-var getJsonScopes = function getJsonScopes() {
-  return getConfigOption('scopes.json');
-};
+const getJsonScopes = () => getConfigOption('scopes.json');
 
-var getGraphQlScopes = function getGraphQlScopes() {
-  return getConfigOption('scopes.graphQl');
-};
+const getGraphQlScopes = () => getConfigOption('scopes.graphQl');
 
-var getMarkdownScopes = function getMarkdownScopes() {
-  return getConfigOption('scopes.markdown');
-};
+const getMarkdownScopes = () => getConfigOption('scopes.markdown');
 
-var getVueScopes = function getVueScopes() {
-  return getConfigOption('scopes.vue');
-};
+const getVueScopes = () => getConfigOption('scopes.vue');
 
-var getAllScopes = function getAllScopes() {
-  return [getJavascriptScopes(), getTypescriptScopes(), getCssScopes(), getJsonScopes(), getGraphQlScopes(), getMarkdownScopes(), getVueScopes()].reduce(function (acc, els) {
-    return acc.concat(els);
-  });
-};
+const getAllScopes = () => [getJavascriptScopes(), getTypescriptScopes(), getCssScopes(), getJsonScopes(), getGraphQlScopes(), getMarkdownScopes(), getVueScopes()].reduce((acc, els) => acc.concat(els));
 
-var getWhitelistedGlobs = function getWhitelistedGlobs() {
-  return getConfigOption('formatOnSaveOptions.whitelistedGlobs');
-};
+const getWhitelistedGlobs = () => getConfigOption('formatOnSaveOptions.whitelistedGlobs');
 
-var getExcludedGlobs = function getExcludedGlobs() {
-  return getConfigOption('formatOnSaveOptions.excludedGlobs');
-};
+const getExcludedGlobs = () => getConfigOption('formatOnSaveOptions.excludedGlobs');
 
-var toggleFormatOnSave = function toggleFormatOnSave() {
-  return setConfigOption('formatOnSaveOptions.enabled', !isFormatOnSaveEnabled());
-};
+const toggleFormatOnSave = () => setConfigOption('formatOnSaveOptions.enabled', !isFormatOnSaveEnabled());
 
-var getAtomTabLength = function getAtomTabLength(editor) {
-  return atom.config.get('editor.tabLength', { scope: editor.getLastCursor().getScopeDescriptor() });
-};
+const getAtomTabLength = editor => atom.config.get('editor.tabLength', { scope: editor.getLastCursor().getScopeDescriptor() });
 
-var getPrettierOptions = function getPrettierOptions() {
-  return getConfigOption('prettierOptions');
-};
+const getPrettierOptions = () => getConfigOption('prettierOptions');
 
-var getPrettierEslintOptions = function getPrettierEslintOptions() {
-  return getConfigOption('prettierEslintOptions');
-};
+const getPrettierEslintOptions = () => getConfigOption('prettierEslintOptions');
 
-var getAtomVersion = function getAtomVersion() {
-  return atom.getVersion();
-};
+const getAtomVersion = () => atom.getVersion();
 
-var getPrettierAtomConfig = function getPrettierAtomConfig() {
-  return atom.config.get('prettier-atom');
-};
+const getPrettierAtomConfig = () => atom.config.get('prettier-atom');
 
-var addTooltip = function addTooltip(element, options) {
-  return atom.tooltips.add(element, options);
-};
+const addTooltip = (element, options) => atom.tooltips.add(element, options);
 
-var addInfoNotification = function addInfoNotification(message, options) {
-  return atom.notifications.addInfo(message, options);
-};
+const addInfoNotification = (message, options) => atom.notifications.addInfo(message, options);
 
-var addWarningNotification = function addWarningNotification(message, options) {
-  return atom.notifications.addWarning(message, options);
-};
+const addWarningNotification = (message, options) => atom.notifications.addWarning(message, options);
 
-var addErrorNotification = function addErrorNotification(message, options) {
-  return atom.notifications.addError(message, options);
-};
+const addErrorNotification = (message, options) => atom.notifications.addError(message, options);
 
-var attemptWithErrorNotification = function () {
-  var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(func) {
-    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-      args[_key - 1] = arguments[_key];
+const attemptWithErrorNotification = (() => {
+  var _ref = (0, _asyncToGenerator3.default)(function* (func, ...args) {
+    try {
+      yield func(...args);
+    } catch (e) {
+      console.error(e); // eslint-disable-line no-console
+      addErrorNotification(e.message, { dismissable: true, stack: e.stack });
     }
-
-    return _regenerator2.default.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            _context.prev = 0;
-            _context.next = 3;
-            return func.apply(undefined, args);
-
-          case 3:
-            _context.next = 9;
-            break;
-
-          case 5:
-            _context.prev = 5;
-            _context.t0 = _context['catch'](0);
-
-            console.error(_context.t0); // eslint-disable-line no-console
-            addErrorNotification(_context.t0.message, { dismissable: true, stack: _context.t0.stack });
-
-          case 9:
-          case 'end':
-            return _context.stop();
-        }
-      }
-    }, _callee, undefined, [[0, 5]]);
-  }));
+  });
 
   return function attemptWithErrorNotification(_x) {
     return _ref.apply(this, arguments);
   };
-}();
+})();
 
-var runLinter = function runLinter(editor) {
-  return isLinterLintCommandDefined(editor) && atom.commands.dispatch(atom.views.getView(editor), LINTER_LINT_COMMAND);
-};
+const runLinter = editor => isLinterLintCommandDefined(editor) && atom.commands.dispatch(atom.views.getView(editor), LINTER_LINT_COMMAND);
 
 module.exports = {
-  addErrorNotification: addErrorNotification,
-  addInfoNotification: addInfoNotification,
-  addTooltip: addTooltip,
-  addWarningNotification: addWarningNotification,
-  getAtomTabLength: getAtomTabLength,
-  getAtomVersion: getAtomVersion,
-  getExcludedGlobs: getExcludedGlobs,
-  getPrettierAtomConfig: getPrettierAtomConfig,
-  getPrettierEslintOptions: getPrettierEslintOptions,
-  getPrettierOptions: getPrettierOptions,
-  getJavascriptScopes: getJavascriptScopes,
-  getTypescriptScopes: getTypescriptScopes,
-  getCssScopes: getCssScopes,
-  getJsonScopes: getJsonScopes,
-  getGraphQlScopes: getGraphQlScopes,
-  getMarkdownScopes: getMarkdownScopes,
-  getVueScopes: getVueScopes,
-  getAllScopes: getAllScopes,
-  getWhitelistedGlobs: getWhitelistedGlobs,
-  isDisabledIfNotInPackageJson: isDisabledIfNotInPackageJson,
-  isDisabledIfNoConfigFile: isDisabledIfNoConfigFile,
-  isFormatOnSaveEnabled: isFormatOnSaveEnabled,
-  isLinterEslintAutofixEnabled: isLinterEslintAutofixEnabled,
-  runLinter: runLinter,
-  shouldRespectEslintignore: shouldRespectEslintignore,
-  shouldUseEditorConfig: shouldUseEditorConfig,
-  shouldUseEslint: shouldUseEslint,
-  shouldUseStylelint: shouldUseStylelint,
-  toggleFormatOnSave: toggleFormatOnSave,
-  attemptWithErrorNotification: attemptWithErrorNotification
+  addErrorNotification,
+  addInfoNotification,
+  addTooltip,
+  addWarningNotification,
+  getAtomTabLength,
+  getAtomVersion,
+  getExcludedGlobs,
+  getPrettierAtomConfig,
+  getPrettierEslintOptions,
+  getPrettierOptions,
+  getJavascriptScopes,
+  getTypescriptScopes,
+  getCssScopes,
+  getJsonScopes,
+  getGraphQlScopes,
+  getMarkdownScopes,
+  getVueScopes,
+  getAllScopes,
+  getWhitelistedGlobs,
+  isDisabledIfNotInPackageJson,
+  isDisabledIfNoConfigFile,
+  isFormatOnSaveEnabled,
+  isLinterEslintAutofixEnabled,
+  runLinter,
+  shouldRespectEslintignore,
+  shouldUseEditorConfig,
+  shouldUseEslint,
+  shouldUseStylelint,
+  toggleFormatOnSave,
+  attemptWithErrorNotification
 };

--- a/dist/displayDebugInfo/index.js
+++ b/dist/displayDebugInfo/index.js
@@ -6,35 +6,30 @@ var _stringify2 = _interopRequireDefault(_stringify);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var readPkgUp = require('read-pkg-up');
-var path = require('path');
+const readPkgUp = require('read-pkg-up');
+const path = require('path');
+const { getAtomVersion, getPrettierAtomConfig, addInfoNotification } = require('../atomInterface');
+const { getGlobalPrettierPath } = require('../helpers/getPrettierPath');
 
-var _require = require('../atomInterface'),
-    getAtomVersion = _require.getAtomVersion,
-    getPrettierAtomConfig = _require.getPrettierAtomConfig,
-    addInfoNotification = _require.addInfoNotification;
+const getDepPath = dep => path.join(__dirname, '..', '..', 'node_modules', dep);
 
-var _require2 = require('../helpers/getPrettierPath'),
-    getGlobalPrettierPath = _require2.getGlobalPrettierPath;
+const getPackageInfo = dir => readPkgUp.sync({ cwd: dir }).pkg;
 
-var getDepPath = function getDepPath(dep) {
-  return path.join(__dirname, '..', '..', 'node_modules', dep);
+const getDebugInfo = () => {
+  const globalPrettierPath = getGlobalPrettierPath();
+  return `
+Atom version: ${getAtomVersion()}
+prettier-atom version: ${getPackageInfo(__dirname).version}
+prettier: ${globalPrettierPath || 'bundled'}
+prettier version: ${getPackageInfo(globalPrettierPath || getDepPath('prettier')).version}
+prettier-eslint version: ${getPackageInfo(getDepPath('prettier-eslint')).version}
+prettier-atom configuration: ${(0, _stringify2.default)(getPrettierAtomConfig(), null, 2)}
+`.trim();
 };
 
-var getPackageInfo = function getPackageInfo(dir) {
-  return readPkgUp.sync({ cwd: dir }).pkg;
-};
-
-var getDebugInfo = function getDebugInfo() {
-  var globalPrettierPath = getGlobalPrettierPath();
-  return ('\nAtom version: ' + getAtomVersion() + '\nprettier-atom version: ' + getPackageInfo(__dirname).version + '\nprettier: ' + (globalPrettierPath || 'bundled') + '\nprettier version: ' + getPackageInfo(globalPrettierPath || getDepPath('prettier')).version + '\nprettier-eslint version: ' + getPackageInfo(getDepPath('prettier-eslint')).version + '\nprettier-atom configuration: ' + (0, _stringify2.default)(getPrettierAtomConfig(), null, 2) + '\n').trim();
-};
-
-var displayDebugInfo = function displayDebugInfo() {
-  return addInfoNotification('prettier-atom: details on current install', {
-    detail: getDebugInfo(),
-    dismissable: true
-  });
-};
+const displayDebugInfo = () => addInfoNotification('prettier-atom: details on current install', {
+  detail: getDebugInfo(),
+  dismissable: true
+});
 
 module.exports = displayDebugInfo;

--- a/dist/editorInterface/index.js
+++ b/dist/editorInterface/index.js
@@ -1,81 +1,58 @@
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var _require = require('../atomInterface'),
-    getCssScopes = _require.getCssScopes,
-    getTypescriptScopes = _require.getTypescriptScopes,
-    getJsonScopes = _require.getJsonScopes,
-    getGraphQlScopes = _require.getGraphQlScopes,
-    getMarkdownScopes = _require.getMarkdownScopes,
-    getVueScopes = _require.getVueScopes;
+const {
+  getCssScopes,
+  getTypescriptScopes,
+  getJsonScopes,
+  getGraphQlScopes,
+  getMarkdownScopes,
+  getVueScopes
+} = require('../atomInterface');
 
-var flow = void 0;
-var lazyFlow = function lazyFlow() {
+let flow;
+const lazyFlow = () => {
   if (!flow) {
     flow = require('lodash/fp/flow'); // eslint-disable-line global-require
   }
   return flow;
 };
 
-var EMBEDDED_SCOPES = ['text.html.basic'];
+const EMBEDDED_SCOPES = ['text.html.basic'];
 
-var getBufferRange = function getBufferRange(editor) {
-  return editor.getBuffer().getRange();
-};
+const getBufferRange = editor => editor.getBuffer().getRange();
 
-var getCurrentScope = function getCurrentScope(editor) {
-  return editor.getGrammar().scopeName;
-};
+const getCurrentScope = editor => editor.getGrammar().scopeName;
 
-var isCurrentScopeEmbeddedScope = function isCurrentScopeEmbeddedScope(editor) {
-  return EMBEDDED_SCOPES.includes(getCurrentScope(editor));
-};
+const isCurrentScopeEmbeddedScope = editor => EMBEDDED_SCOPES.includes(getCurrentScope(editor));
 
-var isCurrentScopeCssScope = function isCurrentScopeCssScope(editor) {
-  return getCssScopes().includes(getCurrentScope(editor));
-};
+const isCurrentScopeCssScope = editor => getCssScopes().includes(getCurrentScope(editor));
 
-var isCurrentScopeTypescriptScope = function isCurrentScopeTypescriptScope(editor) {
-  return getTypescriptScopes().includes(getCurrentScope(editor));
-};
+const isCurrentScopeTypescriptScope = editor => getTypescriptScopes().includes(getCurrentScope(editor));
 
-var isCurrentScopeJsonScope = function isCurrentScopeJsonScope(editor) {
-  return getJsonScopes().includes(getCurrentScope(editor));
-};
+const isCurrentScopeJsonScope = editor => getJsonScopes().includes(getCurrentScope(editor));
 
-var isCurrentScopeGraphQlScope = function isCurrentScopeGraphQlScope(editor) {
-  return getGraphQlScopes().includes(getCurrentScope(editor));
-};
+const isCurrentScopeGraphQlScope = editor => getGraphQlScopes().includes(getCurrentScope(editor));
 
-var isCurrentScopeMarkdownScope = function isCurrentScopeMarkdownScope(editor) {
-  return getMarkdownScopes().includes(getCurrentScope(editor));
-};
+const isCurrentScopeMarkdownScope = editor => getMarkdownScopes().includes(getCurrentScope(editor));
 
-var isCurrentScopeVueScope = function isCurrentScopeVueScope(editor) {
-  return getVueScopes().includes(getCurrentScope(editor));
-};
+const isCurrentScopeVueScope = editor => getVueScopes().includes(getCurrentScope(editor));
 
-var getCurrentFilePath = function getCurrentFilePath(editor) {
-  return editor.buffer.file ? editor.buffer.file.getPath() : undefined;
-};
+const getCurrentFilePath = editor => editor.buffer.file ? editor.buffer.file.getPath() : undefined;
 
-var getCurrentDir = function getCurrentDir(editor) {
-  return lazyFlow()(getCurrentFilePath, function (maybeFilePath) {
-    return typeof maybeFilePath === 'string' ? path.dirname(maybeFilePath) : undefined;
-  })(editor);
-};
+const getCurrentDir = editor => lazyFlow()(getCurrentFilePath, maybeFilePath => typeof maybeFilePath === 'string' ? path.dirname(maybeFilePath) : undefined)(editor);
 
 module.exports = {
-  getBufferRange: getBufferRange,
-  isCurrentScopeEmbeddedScope: isCurrentScopeEmbeddedScope,
-  isCurrentScopeCssScope: isCurrentScopeCssScope,
-  isCurrentScopeTypescriptScope: isCurrentScopeTypescriptScope,
-  isCurrentScopeJsonScope: isCurrentScopeJsonScope,
-  isCurrentScopeGraphQlScope: isCurrentScopeGraphQlScope,
-  isCurrentScopeMarkdownScope: isCurrentScopeMarkdownScope,
-  isCurrentScopeVueScope: isCurrentScopeVueScope,
-  getCurrentScope: getCurrentScope,
-  getCurrentFilePath: getCurrentFilePath,
-  getCurrentDir: getCurrentDir
+  getBufferRange,
+  isCurrentScopeEmbeddedScope,
+  isCurrentScopeCssScope,
+  isCurrentScopeTypescriptScope,
+  isCurrentScopeJsonScope,
+  isCurrentScopeGraphQlScope,
+  isCurrentScopeMarkdownScope,
+  isCurrentScopeVueScope,
+  getCurrentScope,
+  getCurrentFilePath,
+  getCurrentDir
 };

--- a/dist/executePrettier/executePrettierOnBufferRange.js
+++ b/dist/executePrettier/executePrettierOnBufferRange.js
@@ -1,9 +1,5 @@
 'use strict';
 
-var _regenerator = require('babel-runtime/regenerator');
-
-var _regenerator2 = _interopRequireDefault(_regenerator);
-
 var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
 
 var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
@@ -14,207 +10,126 @@ var _extends3 = _interopRequireDefault(_extends2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var _ = require('lodash/fp');
-var prettierEslint = require('prettier-eslint');
-var prettierStylelint = require('prettier-stylelint');
+const _ = require('lodash/fp');
+const prettierEslint = require('prettier-eslint');
+const prettierStylelint = require('prettier-stylelint');
+const { allowUnsafeNewFunction } = require('loophole');
 
-var _require = require('loophole'),
-    allowUnsafeNewFunction = _require.allowUnsafeNewFunction;
+const {
+  getPrettierEslintOptions,
+  shouldUseEslint,
+  shouldUseStylelint,
+  runLinter
+} = require('../atomInterface');
+const { getCurrentFilePath, isCurrentScopeCssScope } = require('../editorInterface');
+const { getPrettierInstance } = require('../helpers');
+const buildPrettierOptions = require('./buildPrettierOptions');
+const handleError = require('./handleError');
 
-var _require2 = require('../atomInterface'),
-    getPrettierEslintOptions = _require2.getPrettierEslintOptions,
-    shouldUseEslint = _require2.shouldUseEslint,
-    shouldUseStylelint = _require2.shouldUseStylelint,
-    runLinter = _require2.runLinter;
-
-var _require3 = require('../editorInterface'),
-    getCurrentFilePath = _require3.getCurrentFilePath,
-    isCurrentScopeCssScope = _require3.isCurrentScopeCssScope;
-
-var _require4 = require('../helpers'),
-    getPrettierInstance = _require4.getPrettierInstance;
-
-var buildPrettierOptions = require('./buildPrettierOptions');
-var handleError = require('./handleError');
-
-var executePrettier = function executePrettier(editor, text
+const executePrettier = (editor, text
 // $FlowFixMe
-) {
-  return getPrettierInstance(editor).format(text, buildPrettierOptions(editor));
-};
+) => getPrettierInstance(editor).format(text, buildPrettierOptions(editor));
 
-var executePrettierWithCursor = function executePrettierWithCursor(editor, text, cursorOffset
+const executePrettierWithCursor = (editor, text, cursorOffset
 // $FlowFixMe
-) {
-  return getPrettierInstance(editor).formatWithCursor(text, (0, _extends3.default)({}, buildPrettierOptions(editor), {
-    cursorOffset: cursorOffset
-  }));
-};
+) => getPrettierInstance(editor).formatWithCursor(text, (0, _extends3.default)({}, buildPrettierOptions(editor), {
+  cursorOffset
+}));
 
-var buildPrettierEslintOptions = function buildPrettierEslintOptions(editor, text) {
-  return (0, _extends3.default)({
-    text: text
-  }, getPrettierEslintOptions(), {
-    fallbackPrettierOptions: buildPrettierOptions(editor),
-    filePath: getCurrentFilePath(editor)
+const buildPrettierEslintOptions = (editor, text) => (0, _extends3.default)({
+  text
+}, getPrettierEslintOptions(), {
+  fallbackPrettierOptions: buildPrettierOptions(editor),
+  filePath: getCurrentFilePath(editor)
+});
+
+const executePrettierEslint = (editor, text) => allowUnsafeNewFunction(() => prettierEslint(buildPrettierEslintOptions(editor, text)));
+
+const buildPrettierStylelintOptions = (editor, text) => ({
+  text,
+  prettierOptions: buildPrettierOptions(editor),
+  filePath: getCurrentFilePath(editor)
+});
+
+const executePrettierStylelint = (editor, text) => prettierStylelint.format(buildPrettierStylelintOptions(editor, text));
+
+const executePrettierOrIntegration = (() => {
+  var _ref = (0, _asyncToGenerator3.default)(function* (editor, text, cursorOffset) {
+    if (shouldUseStylelint() && isCurrentScopeCssScope(editor)) {
+      // TODO: add support for cursor position - https://github.com/hugomrdias/prettier-stylelint/issues/13
+      const formatted = yield executePrettierStylelint(editor, text);
+
+      return { formatted, cursorOffset };
+    }
+
+    if (shouldUseEslint()) {
+      // TODO: add support for cursor position - https://github.com/prettier/prettier-eslint/issues/164
+      const formatted = executePrettierEslint(editor, text);
+
+      return { formatted, cursorOffset };
+    }
+
+    let formatted;
+
+    // TODO: remove this try/catch once Prettier.formatWithCursor stabilizes
+    try {
+      formatted = executePrettierWithCursor(editor, text, cursorOffset).formatted;
+    } catch (error) {
+      formatted = executePrettier(editor, text);
+    }
+
+    return { formatted, cursorOffset };
   });
-};
-
-var executePrettierEslint = function executePrettierEslint(editor, text) {
-  return allowUnsafeNewFunction(function () {
-    return prettierEslint(buildPrettierEslintOptions(editor, text));
-  });
-};
-
-var buildPrettierStylelintOptions = function buildPrettierStylelintOptions(editor, text) {
-  return {
-    text: text,
-    prettierOptions: buildPrettierOptions(editor),
-    filePath: getCurrentFilePath(editor)
-  };
-};
-
-var executePrettierStylelint = function executePrettierStylelint(editor, text) {
-  return prettierStylelint.format(buildPrettierStylelintOptions(editor, text));
-};
-
-var executePrettierOrIntegration = function () {
-  var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(editor, text, cursorOffset) {
-    var _formatted, _formatted2, formatted;
-
-    return _regenerator2.default.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            if (!(shouldUseStylelint() && isCurrentScopeCssScope(editor))) {
-              _context.next = 5;
-              break;
-            }
-
-            _context.next = 3;
-            return executePrettierStylelint(editor, text);
-
-          case 3:
-            _formatted = _context.sent;
-            return _context.abrupt('return', { formatted: _formatted, cursorOffset: cursorOffset });
-
-          case 5:
-            if (!shouldUseEslint()) {
-              _context.next = 8;
-              break;
-            }
-
-            // TODO: add support for cursor position - https://github.com/prettier/prettier-eslint/issues/164
-            _formatted2 = executePrettierEslint(editor, text);
-            return _context.abrupt('return', { formatted: _formatted2, cursorOffset: cursorOffset });
-
-          case 8:
-            formatted = void 0;
-
-            // TODO: remove this try/catch once Prettier.formatWithCursor stabilizes
-
-            try {
-              formatted = executePrettierWithCursor(editor, text, cursorOffset).formatted;
-            } catch (error) {
-              formatted = executePrettier(editor, text);
-            }
-
-            return _context.abrupt('return', { formatted: formatted, cursorOffset: cursorOffset });
-
-          case 11:
-          case 'end':
-            return _context.stop();
-        }
-      }
-    }, _callee, undefined);
-  }));
 
   return function executePrettierOrIntegration(_x, _x2, _x3) {
     return _ref.apply(this, arguments);
   };
-}();
+})();
 
-var executePrettierOnBufferRange = function () {
-  var _ref2 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(editor, bufferRange, options) {
-    var currentBuffer, cursorPosition, textToTransform, cursorOffset, results, isTextUnchanged, nextCursorPosition;
-    return _regenerator2.default.wrap(function _callee2$(_context2) {
-      while (1) {
-        switch (_context2.prev = _context2.next) {
-          case 0:
-            // grab cursor position and file contents
-            currentBuffer = editor.getBuffer();
-            cursorPosition = editor.getCursorBufferPosition();
-            textToTransform = editor.getTextInBufferRange(bufferRange);
-            cursorOffset = currentBuffer.characterIndexForPosition(cursorPosition);
-            results = {
-              cursorOffset: cursorOffset,
-              formatted: textToTransform
-            };
+const executePrettierOnBufferRange = (() => {
+  var _ref2 = (0, _asyncToGenerator3.default)(function* (editor, bufferRange, options) {
+    // grab cursor position and file contents
+    const currentBuffer = editor.getBuffer();
+    const cursorPosition = editor.getCursorBufferPosition();
+    const textToTransform = editor.getTextInBufferRange(bufferRange);
+    const cursorOffset = currentBuffer.characterIndexForPosition(cursorPosition);
+    let results = {
+      cursorOffset,
+      formatted: textToTransform
+    };
 
-            if (!_.isEmpty(textToTransform)) {
-              _context2.next = 7;
-              break;
-            }
+    if (_.isEmpty(textToTransform)) return;
 
-            return _context2.abrupt('return');
+    try {
+      results = yield executePrettierOrIntegration(editor, textToTransform, cursorOffset);
+    } catch (error) {
+      handleError({ editor, bufferRange, error });
+      return;
+    }
 
-          case 7:
-            _context2.prev = 7;
-            _context2.next = 10;
-            return executePrettierOrIntegration(editor, textToTransform, cursorOffset);
+    const isTextUnchanged = results.formatted === textToTransform;
+    if (isTextUnchanged) return;
 
-          case 10:
-            results = _context2.sent;
-            _context2.next = 17;
-            break;
+    if (options && options.setTextViaDiff) {
+      // we use setTextViaDiff when formatting the entire buffer to improve performance,
+      // maintain metadata (bookmarks, folds, etc) and eliminate syntax highlight flickering
+      // however, we can't always use it because it replaces all text in the file and sometimes
+      // we're only editing a sub-selection of the text in a file
+      currentBuffer.setTextViaDiff(results.formatted);
+    } else {
+      editor.setTextInBufferRange(bufferRange, results.formatted);
+    }
 
-          case 13:
-            _context2.prev = 13;
-            _context2.t0 = _context2['catch'](7);
+    // calculate next cursor position after buffer has been updated with new text
+    const nextCursorPosition = currentBuffer.positionForCharacterIndex(results.cursorOffset);
 
-            handleError({ editor: editor, bufferRange: bufferRange, error: _context2.t0 });
-            return _context2.abrupt('return');
-
-          case 17:
-            isTextUnchanged = results.formatted === textToTransform;
-
-            if (!isTextUnchanged) {
-              _context2.next = 20;
-              break;
-            }
-
-            return _context2.abrupt('return');
-
-          case 20:
-
-            if (options && options.setTextViaDiff) {
-              // we use setTextViaDiff when formatting the entire buffer to improve performance,
-              // maintain metadata (bookmarks, folds, etc) and eliminate syntax highlight flickering
-              // however, we can't always use it because it replaces all text in the file and sometimes
-              // we're only editing a sub-selection of the text in a file
-              currentBuffer.setTextViaDiff(results.formatted);
-            } else {
-              editor.setTextInBufferRange(bufferRange, results.formatted);
-            }
-
-            // calculate next cursor position after buffer has been updated with new text
-            nextCursorPosition = currentBuffer.positionForCharacterIndex(results.cursorOffset);
-
-
-            editor.setCursorBufferPosition(nextCursorPosition);
-            runLinter(editor);
-
-          case 24:
-          case 'end':
-            return _context2.stop();
-        }
-      }
-    }, _callee2, undefined, [[7, 13]]);
-  }));
+    editor.setCursorBufferPosition(nextCursorPosition);
+    runLinter(editor);
+  });
 
   return function executePrettierOnBufferRange(_x4, _x5, _x6) {
     return _ref2.apply(this, arguments);
   };
-}();
+})();
 
 module.exports = executePrettierOnBufferRange;

--- a/dist/executePrettier/executePrettierOnEmbeddedScripts.js
+++ b/dist/executePrettier/executePrettierOnEmbeddedScripts.js
@@ -1,35 +1,24 @@
 'use strict';
 
-var executePrettierOnBufferRange = require('./executePrettierOnBufferRange');
+const executePrettierOnBufferRange = require('./executePrettierOnBufferRange');
+const { getBufferRange } = require('../editorInterface');
+const { createRange, createPoint } = require('../helpers');
 
-var _require = require('../editorInterface'),
-    getBufferRange = _require.getBufferRange;
+const EMBEDDED_JS_REGEX = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi;
 
-var _require2 = require('../helpers'),
-    createRange = _require2.createRange,
-    createPoint = _require2.createPoint;
+const backwardsScanIterator = editor => ({ range: matchingRange }) => {
+  // Skip formatting when <script> and </script> on the same line
+  if (matchingRange.start.row === matchingRange.end.row) return;
 
-var EMBEDDED_JS_REGEX = /<script\b[^>]*>([\s\S]*?)(?=<\/script>)/gi;
+  // Create new range with start row advanced by 1,
+  // since we cannot use look-behind on variable-length starting
+  // <script ...> tag
+  const nextStartPoint = createPoint(matchingRange.start.row + 1, matchingRange.start.column);
+  const bufferRange = createRange(nextStartPoint, matchingRange.end);
 
-var backwardsScanIterator = function backwardsScanIterator(editor) {
-  return function (_ref) {
-    var matchingRange = _ref.range;
-
-    // Skip formatting when <script> and </script> on the same line
-    if (matchingRange.start.row === matchingRange.end.row) return;
-
-    // Create new range with start row advanced by 1,
-    // since we cannot use look-behind on variable-length starting
-    // <script ...> tag
-    var nextStartPoint = createPoint(matchingRange.start.row + 1, matchingRange.start.column);
-    var bufferRange = createRange(nextStartPoint, matchingRange.end);
-
-    executePrettierOnBufferRange(editor, bufferRange);
-  };
+  executePrettierOnBufferRange(editor, bufferRange);
 };
 
-var executePrettierOnEmbeddedScripts = function executePrettierOnEmbeddedScripts(editor) {
-  return editor.backwardsScanInBufferRange(EMBEDDED_JS_REGEX, getBufferRange(editor), backwardsScanIterator(editor));
-};
+const executePrettierOnEmbeddedScripts = editor => editor.backwardsScanInBufferRange(EMBEDDED_JS_REGEX, getBufferRange(editor), backwardsScanIterator(editor));
 
 module.exports = executePrettierOnEmbeddedScripts;

--- a/dist/executePrettier/handleError.js
+++ b/dist/executePrettier/handleError.js
@@ -1,64 +1,40 @@
 'use strict';
 
-var _ = require('lodash/fp');
+const _ = require('lodash/fp');
+const { getCurrentFilePath } = require('../editorInterface');
+const linter = require('../linterInterface');
+const { addErrorNotification } = require('../atomInterface');
+const { createPoint, createRange } = require('../helpers');
 
-var _require = require('../editorInterface'),
-    getCurrentFilePath = _require.getCurrentFilePath;
+const errorLine = error => error.loc.start ? error.loc.start.line : error.loc.line;
 
-var linter = require('../linterInterface');
-
-var _require2 = require('../atomInterface'),
-    addErrorNotification = _require2.addErrorNotification;
-
-var _require3 = require('../helpers'),
-    createPoint = _require3.createPoint,
-    createRange = _require3.createRange;
-
-var errorLine = function errorLine(error) {
-  return error.loc.start ? error.loc.start.line : error.loc.line;
-};
-
-var errorColumn = function errorColumn(error) {
-  return error.loc.start ? error.loc.start.column : error.loc.column;
-};
+const errorColumn = error => error.loc.start ? error.loc.start.column : error.loc.column;
 
 // NOTE: Prettier error locations are not zero-based (i.e., they start at 1)
-var buildPointArrayFromPrettierErrorAndRange = function buildPointArrayFromPrettierErrorAndRange(error, bufferRange) {
-  return createPoint(errorLine(error) + bufferRange.start.row - 1, errorLine(error) === 0 ? errorColumn(error) + bufferRange.start.column - 1 : errorColumn(error) - 1);
-};
+const buildPointArrayFromPrettierErrorAndRange = (error, bufferRange) => createPoint(errorLine(error) + bufferRange.start.row - 1, errorLine(error) === 0 ? errorColumn(error) + bufferRange.start.column - 1 : errorColumn(error) - 1);
 
-var buildExcerpt = function buildExcerpt(error) {
-  return (/(.*)\s\(\d+:\d+\).*/.exec(error.message)[1]
-  );
-};
+const buildExcerpt = error => /(.*)\s\(\d+:\d+\).*/.exec(error.message)[1];
 
-var setErrorMessageInLinter = function setErrorMessageInLinter(_ref) {
-  var editor = _ref.editor,
-      bufferRange = _ref.bufferRange,
-      error = _ref.error;
-  return linter.setMessages(editor, [{
-    location: {
-      // $$FlowFixMe
-      file: getCurrentFilePath(editor),
-      position: createRange(buildPointArrayFromPrettierErrorAndRange(error, bufferRange), buildPointArrayFromPrettierErrorAndRange(error, bufferRange))
-    },
-    excerpt: buildExcerpt(error),
-    severity: 'error'
-  }]);
-};
+const setErrorMessageInLinter = ({ editor, bufferRange, error }) => linter.setMessages(editor, [{
+  location: {
+    // $$FlowFixMe
+    file: getCurrentFilePath(editor),
+    position: createRange(buildPointArrayFromPrettierErrorAndRange(error, bufferRange), buildPointArrayFromPrettierErrorAndRange(error, bufferRange))
+  },
+  excerpt: buildExcerpt(error),
+  severity: 'error'
+}]);
 
-var isSyntaxError = _.overSome([_.flow(_.get('error.loc.start.line'), _.isInteger), _.flow(_.get('error.loc.line'), _.isInteger)]);
+const isSyntaxError = _.overSome([_.flow(_.get('error.loc.start.line'), _.isInteger), _.flow(_.get('error.loc.line'), _.isInteger)]);
 
-var isFilePathPresent = _.flow(_.get('editor'), getCurrentFilePath, _.negate(_.isNil));
+const isFilePathPresent = _.flow(_.get('editor'), getCurrentFilePath, _.negate(_.isNil));
 
-var displayErrorInPopup = function displayErrorInPopup(args) {
-  return console.error(args.error) || // eslint-disable-line no-console
-  addErrorNotification('prettier-atom failed: ' + args.error.message, {
-    stack: args.error.stack,
-    dismissable: true
-  });
-};
+const displayErrorInPopup = args => console.error(args.error) || // eslint-disable-line no-console
+addErrorNotification(`prettier-atom failed: ${args.error.message}`, {
+  stack: args.error.stack,
+  dismissable: true
+});
 
-var handleError = _.flow(_.cond([[_.overEvery([isSyntaxError, isFilePathPresent]), setErrorMessageInLinter], [_.stubTrue, displayErrorInPopup]]));
+const handleError = _.flow(_.cond([[_.overEvery([isSyntaxError, isFilePathPresent]), setErrorMessageInLinter], [_.stubTrue, displayErrorInPopup]]));
 
 module.exports = handleError;

--- a/dist/executePrettier/index.js
+++ b/dist/executePrettier/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var executePrettierOnBufferRange = require('./executePrettierOnBufferRange');
-var executePrettierOnEmbeddedScripts = require('./executePrettierOnEmbeddedScripts.js');
+const executePrettierOnBufferRange = require('./executePrettierOnBufferRange');
+const executePrettierOnEmbeddedScripts = require('./executePrettierOnEmbeddedScripts.js');
 
 module.exports = {
-  executePrettierOnBufferRange: executePrettierOnBufferRange,
-  executePrettierOnEmbeddedScripts: executePrettierOnEmbeddedScripts
+  executePrettierOnBufferRange,
+  executePrettierOnEmbeddedScripts
 };

--- a/dist/formatOnSave/isFilePathEslintIgnored.js
+++ b/dist/formatOnSave/isFilePathEslintIgnored.js
@@ -1,38 +1,26 @@
 'use strict';
 
-var _ = require('lodash/fp');
-var path = require('path');
-var fs = require('fs');
+const _ = require('lodash/fp');
+const path = require('path');
+const fs = require('fs');
+const { findCachedFromFilePath, getDirFromFilePath, someGlobsMatchFilePath } = require('../helpers');
 
-var _require = require('../helpers'),
-    findCachedFromFilePath = _require.findCachedFromFilePath,
-    getDirFromFilePath = _require.getDirFromFilePath,
-    someGlobsMatchFilePath = _require.someGlobsMatchFilePath;
+const LINE_SEPERATOR_REGEX = /(\r|\n|\r\n)/;
 
-var LINE_SEPERATOR_REGEX = /(\r|\n|\r\n)/;
+const getNearestEslintignorePath = filePath => findCachedFromFilePath(filePath, '.eslintignore');
 
-var getNearestEslintignorePath = function getNearestEslintignorePath(filePath) {
-  return findCachedFromFilePath(filePath, '.eslintignore');
-};
-
-var safeRelativePath = _.curry(
+const safeRelativePath = _.curry(
 // $FlowFixMe
-function (from, to) {
-  return !!from && !!to ? path.relative(from, to) : undefined;
-});
+(from, to) => !!from && !!to ? path.relative(from, to) : undefined);
 
-var getFilePathRelativeToEslintignore = function getFilePathRelativeToEslintignore(filePath
+const getFilePathRelativeToEslintignore = (filePath
 // $FlowIssue: lodashfp placeholders not supported yet
-) {
-  return _.flow(getNearestEslintignorePath, getDirFromFilePath, safeRelativePath(_, filePath))(filePath);
-};
+) => _.flow(getNearestEslintignorePath, getDirFromFilePath, safeRelativePath(_, filePath))(filePath);
 
-var getLinesFromFilePath = function getLinesFromFilePath(filePath) {
-  return !!filePath && filePath.length > 0 ? fs.readFileSync(filePath, 'utf8').split(LINE_SEPERATOR_REGEX) : [];
-};
+const getLinesFromFilePath = filePath => !!filePath && filePath.length > 0 ? fs.readFileSync(filePath, 'utf8').split(LINE_SEPERATOR_REGEX) : [];
 
-var getIgnoredGlobsFromNearestEslintIgnore = _.flow(getNearestEslintignorePath, getLinesFromFilePath);
+const getIgnoredGlobsFromNearestEslintIgnore = _.flow(getNearestEslintignorePath, getLinesFromFilePath);
 
-var isFilePathEslintignored = _.flow(_.over([getIgnoredGlobsFromNearestEslintIgnore, getFilePathRelativeToEslintignore]), _.spread(someGlobsMatchFilePath));
+const isFilePathEslintignored = _.flow(_.over([getIgnoredGlobsFromNearestEslintIgnore, getFilePathRelativeToEslintignore]), _.spread(someGlobsMatchFilePath));
 
 module.exports = isFilePathEslintignored;

--- a/dist/formatOnSave/isFilePathPrettierIgnored.js
+++ b/dist/formatOnSave/isFilePathPrettierIgnored.js
@@ -1,38 +1,26 @@
 'use strict';
 
-var _ = require('lodash/fp');
-var path = require('path');
-var fs = require('fs');
+const _ = require('lodash/fp');
+const path = require('path');
+const fs = require('fs');
+const { findCachedFromFilePath, getDirFromFilePath, someGlobsMatchFilePath } = require('../helpers');
 
-var _require = require('../helpers'),
-    findCachedFromFilePath = _require.findCachedFromFilePath,
-    getDirFromFilePath = _require.getDirFromFilePath,
-    someGlobsMatchFilePath = _require.someGlobsMatchFilePath;
+const LINE_SEPERATOR_REGEX = /(\r|\n|\r\n)/;
 
-var LINE_SEPERATOR_REGEX = /(\r|\n|\r\n)/;
+const getNearestPrettierIgnorePath = filePath => findCachedFromFilePath(filePath, '.prettierignore');
 
-var getNearestPrettierIgnorePath = function getNearestPrettierIgnorePath(filePath) {
-  return findCachedFromFilePath(filePath, '.prettierignore');
-};
-
-var safeRelativePath = _.curry(
+const safeRelativePath = _.curry(
 // $FlowFixMe
-function (from, to) {
-  return !!from && !!to ? path.relative(from, to) : undefined;
-});
+(from, to) => !!from && !!to ? path.relative(from, to) : undefined);
 
-var getFilePathRelativeToPrettierIgnore = function getFilePathRelativeToPrettierIgnore(filePath
+const getFilePathRelativeToPrettierIgnore = (filePath
 // $FlowIssue: lodashfp placeholders not supported yet
-) {
-  return _.flow(getNearestPrettierIgnorePath, getDirFromFilePath, safeRelativePath(_, filePath))(filePath);
-};
+) => _.flow(getNearestPrettierIgnorePath, getDirFromFilePath, safeRelativePath(_, filePath))(filePath);
 
-var getLinesFromFilePath = function getLinesFromFilePath(filePath) {
-  return !!filePath && filePath.length > 0 ? fs.readFileSync(filePath, 'utf8').split(LINE_SEPERATOR_REGEX) : [];
-};
+const getLinesFromFilePath = filePath => !!filePath && filePath.length > 0 ? fs.readFileSync(filePath, 'utf8').split(LINE_SEPERATOR_REGEX) : [];
 
-var getIgnoredGlobsFromNearestPrettierIgnore = _.flow(getNearestPrettierIgnorePath, getLinesFromFilePath);
+const getIgnoredGlobsFromNearestPrettierIgnore = _.flow(getNearestPrettierIgnorePath, getLinesFromFilePath);
 
-var isFilePathPrettierIgnored = _.flow(_.over([getIgnoredGlobsFromNearestPrettierIgnore, getFilePathRelativeToPrettierIgnore]), _.spread(someGlobsMatchFilePath));
+const isFilePathPrettierIgnored = _.flow(_.over([getIgnoredGlobsFromNearestPrettierIgnore, getFilePathRelativeToPrettierIgnore]), _.spread(someGlobsMatchFilePath));
 
 module.exports = isFilePathPrettierIgnored;

--- a/dist/formatOnSave/isPrettierInPackageJson.js
+++ b/dist/formatOnSave/isPrettierInPackageJson.js
@@ -1,32 +1,23 @@
 'use strict';
 
-var _ = require('lodash/fp');
-var readPgkUp = require('read-pkg-up');
+const _ = require('lodash/fp');
+const readPgkUp = require('read-pkg-up');
 
-var _require = require('../editorInterface'),
-    getCurrentDir = _require.getCurrentDir;
+const { getCurrentDir } = require('../editorInterface');
+const { shouldUseEslint } = require('../atomInterface');
 
-var _require2 = require('../atomInterface'),
-    shouldUseEslint = _require2.shouldUseEslint;
+const hasPackageDependency = packageName => _.flow(_.get('pkg.dependencies'), _.has(packageName));
 
-var hasPackageDependency = function hasPackageDependency(packageName) {
-  return _.flow(_.get('pkg.dependencies'), _.has(packageName));
-};
+const hasPackageDevDependency = packageName => _.flow(_.get('pkg.devDependencies'), _.has(packageName));
 
-var hasPackageDevDependency = function hasPackageDevDependency(packageName) {
-  return _.flow(_.get('pkg.devDependencies'), _.has(packageName));
-};
+const hasPackage = packageName => _.overSome([hasPackageDependency(packageName), hasPackageDevDependency(packageName)]);
 
-var hasPackage = function hasPackage(packageName) {
-  return _.overSome([hasPackageDependency(packageName), hasPackageDevDependency(packageName)]);
-};
-
-var readContentsOfNearestPackageJson = _.flow(getCurrentDir,
+const readContentsOfNearestPackageJson = _.flow(getCurrentDir,
 // $FlowIssue: lodashfp placeholders not supported yet
 _.set('cwd', _, {}), readPgkUp.sync);
 
-var isPrettierInPackageJson = _.flow(readContentsOfNearestPackageJson, hasPackage('prettier'));
+const isPrettierInPackageJson = _.flow(readContentsOfNearestPackageJson, hasPackage('prettier'));
 
-var isPrettierEslintInPackageJson = _.flow(readContentsOfNearestPackageJson, _.overSome([hasPackage('prettier-eslint'), hasPackage('prettier-eslint-cli'), hasPackage('eslint-plugin-prettier')]));
+const isPrettierEslintInPackageJson = _.flow(readContentsOfNearestPackageJson, _.overSome([hasPackage('prettier-eslint'), hasPackage('prettier-eslint-cli'), hasPackage('eslint-plugin-prettier')]));
 
 module.exports = _.cond([[shouldUseEslint, isPrettierEslintInPackageJson], [_.stubTrue, isPrettierInPackageJson]]);

--- a/dist/formatOnSave/shouldFormatOnSave.js
+++ b/dist/formatOnSave/shouldFormatOnSave.js
@@ -1,58 +1,41 @@
 'use strict';
 
-var _ = require('lodash/fp');
+const _ = require('lodash/fp');
+const { someGlobsMatchFilePath, getPrettierInstance } = require('../helpers');
+const { getCurrentFilePath, getCurrentScope } = require('../editorInterface');
+const {
+  isFormatOnSaveEnabled,
+  getAllScopes,
+  getExcludedGlobs,
+  getWhitelistedGlobs,
+  isDisabledIfNotInPackageJson,
+  isDisabledIfNoConfigFile,
+  shouldRespectEslintignore
+} = require('../atomInterface');
+const isFilePathEslintIgnored = require('./isFilePathEslintIgnored');
+const isFilePathPrettierIgnored = require('./isFilePathPrettierIgnored');
+const isPrettierInPackageJson = require('./isPrettierInPackageJson');
 
-var _require = require('../helpers'),
-    someGlobsMatchFilePath = _require.someGlobsMatchFilePath,
-    getPrettierInstance = _require.getPrettierInstance;
+const hasFilePath = editor => !!getCurrentFilePath(editor);
 
-var _require2 = require('../editorInterface'),
-    getCurrentFilePath = _require2.getCurrentFilePath,
-    getCurrentScope = _require2.getCurrentScope;
+const isInScope = editor => getAllScopes().includes(getCurrentScope(editor));
 
-var _require3 = require('../atomInterface'),
-    isFormatOnSaveEnabled = _require3.isFormatOnSaveEnabled,
-    getAllScopes = _require3.getAllScopes,
-    getExcludedGlobs = _require3.getExcludedGlobs,
-    getWhitelistedGlobs = _require3.getWhitelistedGlobs,
-    isDisabledIfNotInPackageJson = _require3.isDisabledIfNotInPackageJson,
-    isDisabledIfNoConfigFile = _require3.isDisabledIfNoConfigFile,
-    shouldRespectEslintignore = _require3.shouldRespectEslintignore;
-
-var isFilePathEslintIgnored = require('./isFilePathEslintIgnored');
-var isFilePathPrettierIgnored = require('./isFilePathPrettierIgnored');
-var isPrettierInPackageJson = require('./isPrettierInPackageJson');
-
-var hasFilePath = function hasFilePath(editor) {
-  return !!getCurrentFilePath(editor);
-};
-
-var isInScope = function isInScope(editor) {
-  return getAllScopes().includes(getCurrentScope(editor));
-};
-
-var filePathDoesNotMatchBlacklistGlobs = _.flow(getCurrentFilePath, function (filePath) {
-  return _.negate(someGlobsMatchFilePath)(getExcludedGlobs(), filePath);
-});
+const filePathDoesNotMatchBlacklistGlobs = _.flow(getCurrentFilePath, filePath => _.negate(someGlobsMatchFilePath)(getExcludedGlobs(), filePath));
 
 // $FlowFixMe
-var noWhitelistGlobsPresent = _.flow(getWhitelistedGlobs, _.isEmpty);
+const noWhitelistGlobsPresent = _.flow(getWhitelistedGlobs, _.isEmpty);
 
-var isFilePathWhitelisted = _.flow(getCurrentFilePath, function (filePath) {
-  return someGlobsMatchFilePath(getWhitelistedGlobs(), filePath);
-});
-var isEslintIgnored = _.flow(getCurrentFilePath, isFilePathEslintIgnored);
+const isFilePathWhitelisted = _.flow(getCurrentFilePath, filePath => someGlobsMatchFilePath(getWhitelistedGlobs(), filePath));
+const isEslintIgnored = _.flow(getCurrentFilePath, isFilePathEslintIgnored);
 
-var isFilePathNotPrettierIgnored = _.flow(getCurrentFilePath, _.negate(isFilePathPrettierIgnored));
+const isFilePathNotPrettierIgnored = _.flow(getCurrentFilePath, _.negate(isFilePathPrettierIgnored));
 
-var isPrettierConfigPresent = function isPrettierConfigPresent(editor
+const isPrettierConfigPresent = (editor
 // $FlowFixMe
-) {
-  return !!getPrettierInstance(editor).resolveConfig.sync &&
-  // $FlowFixMe
-  _.flow(getCurrentFilePath, getPrettierInstance(editor).resolveConfig.sync, _.negate(_.isNil))(editor);
-};
+) => !!getPrettierInstance(editor).resolveConfig.sync &&
+// $FlowFixMe
+_.flow(getCurrentFilePath, getPrettierInstance(editor).resolveConfig.sync, _.negate(_.isNil))(editor);
 
-var shouldFormatOnSave = _.overEvery([isFormatOnSaveEnabled, hasFilePath, isInScope, _.overSome([isFilePathWhitelisted, _.overEvery([noWhitelistGlobsPresent, filePathDoesNotMatchBlacklistGlobs])]), _.overSome([_.negate(shouldRespectEslintignore), _.negate(isEslintIgnored)]), isFilePathNotPrettierIgnored, _.overSome([_.negate(isDisabledIfNotInPackageJson), isPrettierInPackageJson]), _.overSome([_.negate(isDisabledIfNoConfigFile), isPrettierConfigPresent])]);
+const shouldFormatOnSave = _.overEvery([isFormatOnSaveEnabled, hasFilePath, isInScope, _.overSome([isFilePathWhitelisted, _.overEvery([noWhitelistGlobsPresent, filePathDoesNotMatchBlacklistGlobs])]), _.overSome([_.negate(shouldRespectEslintignore), _.negate(isEslintIgnored)]), isFilePathNotPrettierIgnored, _.overSome([_.negate(isDisabledIfNotInPackageJson), isPrettierInPackageJson]), _.overSome([_.negate(isDisabledIfNoConfigFile), isPrettierConfigPresent])]);
 
 module.exports = shouldFormatOnSave;

--- a/dist/helpers/atomRelated.js
+++ b/dist/helpers/atomRelated.js
@@ -1,17 +1,13 @@
 'use strict';
 
-var Point = require('atom-text-buffer-point');
-var Range = require('atom-text-buffer-range');
+const Point = require('atom-text-buffer-point');
+const Range = require('atom-text-buffer-range');
 
-var createPoint = function createPoint(row, column) {
-  return new Point(row, column);
-};
+const createPoint = (row, column) => new Point(row, column);
 
-var createRange = function createRange(start, end) {
-  return new Range(start, end);
-};
+const createRange = (start, end) => new Range(start, end);
 
 module.exports = {
-  createPoint: createPoint,
-  createRange: createRange
+  createPoint,
+  createRange
 };

--- a/dist/helpers/general.js
+++ b/dist/helpers/general.js
@@ -1,36 +1,24 @@
 'use strict';
 
-var _ = require('lodash/fp');
-var ignore = require('ignore');
-var path = require('path');
+const _ = require('lodash/fp');
+const ignore = require('ignore');
+const path = require('path');
+const { findCached } = require('atom-linter');
 
-var _require = require('atom-linter'),
-    findCached = _require.findCached;
+const isPresent = target => !!target && (typeof target.length === 'undefined' || target.length > 0);
 
-var isPresent = function isPresent(target) {
-  return !!target && (typeof target.length === 'undefined' || target.length > 0);
-};
+const someGlobsMatchFilePath = (globs, filePath) => isPresent(filePath) && ignore().add(globs).ignores(filePath);
 
-var someGlobsMatchFilePath = function someGlobsMatchFilePath(globs, filePath) {
-  return isPresent(filePath) && ignore().add(globs).ignores(filePath);
-};
-
-var safePathParse = function safePathParse(filePath) {
-  return typeof filePath === 'string' && filePath.length > 0 ? path.parse(filePath) : undefined;
-};
+const safePathParse = filePath => typeof filePath === 'string' && filePath.length > 0 ? path.parse(filePath) : undefined;
 
 // $FlowFixMe: calling `_.get` on possibly undefined value
-var getDirFromFilePath = _.flow(safePathParse, _.get('dir'));
+const getDirFromFilePath = _.flow(safePathParse, _.get('dir'));
 
-var findCachedFromFilePath = function findCachedFromFilePath(filePath, name) {
-  return _.flow(getDirFromFilePath, function (dirPath) {
-    return isPresent(dirPath) ? findCached(dirPath, name) : undefined;
-  })(filePath);
-};
+const findCachedFromFilePath = (filePath, name) => _.flow(getDirFromFilePath, dirPath => isPresent(dirPath) ? findCached(dirPath, name) : undefined)(filePath);
 
 module.exports = {
-  isPresent: isPresent,
-  someGlobsMatchFilePath: someGlobsMatchFilePath,
-  getDirFromFilePath: getDirFromFilePath,
-  findCachedFromFilePath: findCachedFromFilePath
+  isPresent,
+  someGlobsMatchFilePath,
+  getDirFromFilePath,
+  findCachedFromFilePath
 };

--- a/dist/helpers/getPrettierInstance.js
+++ b/dist/helpers/getPrettierInstance.js
@@ -1,27 +1,19 @@
 'use strict';
 
-var _ = require('lodash/fp');
-var bundledPrettier = require('prettier');
-
-var _require = require('../editorInterface'),
-    getCurrentFilePath = _require.getCurrentFilePath;
-
-var _require2 = require('./getPrettierPath'),
-    getLocalOrGlobalPrettierPath = _require2.getLocalOrGlobalPrettierPath;
+const _ = require('lodash/fp');
+const bundledPrettier = require('prettier');
+const { getCurrentFilePath } = require('../editorInterface');
+const { getLocalOrGlobalPrettierPath } = require('./getPrettierPath');
 
 // charypar: This is currently the best way to use local prettier instance.
 // Using the CLI introduces a noticeable delay and there is currently no
 // way to use prettier as a long-running process for formatting files as needed
 //
 // See https://github.com/prettier/prettier/issues/918
-
-
-var requireWithFallbackToBundledPrettier = function requireWithFallbackToBundledPrettier(prettierPackagePath
+const requireWithFallbackToBundledPrettier = (prettierPackagePath
 // $$FlowFixMe
-) {
-  return prettierPackagePath ? require(prettierPackagePath) : bundledPrettier;
-}; // eslint-disable-line
+) => prettierPackagePath ? require(prettierPackagePath) : bundledPrettier; // eslint-disable-line
 
-var getPrettierInstance = _.flow(getCurrentFilePath, getLocalOrGlobalPrettierPath, requireWithFallbackToBundledPrettier);
+const getPrettierInstance = _.flow(getCurrentFilePath, getLocalOrGlobalPrettierPath, requireWithFallbackToBundledPrettier);
 
 module.exports = getPrettierInstance;

--- a/dist/helpers/getPrettierPath.js
+++ b/dist/helpers/getPrettierPath.js
@@ -1,32 +1,21 @@
 'use strict';
 
-var _require = require('./general'),
-    findCachedFromFilePath = _require.findCachedFromFilePath;
+const { findCachedFromFilePath } = require('./general');
+const path = require('path');
+const { findCached } = require('atom-linter');
+const globalModules = require('global-modules');
+const yarnGlobalModules = require('yarn-global-modules')();
 
-var path = require('path');
+const PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js');
 
-var _require2 = require('atom-linter'),
-    findCached = _require2.findCached;
+const getGlobalPrettierPath = () => findCached(globalModules, PRETTIER_INDEX_PATH) || findCached(yarnGlobalModules, PRETTIER_INDEX_PATH);
 
-var globalModules = require('global-modules');
-var yarnGlobalModules = require('yarn-global-modules')();
+const getLocalPrettierPath = filePath => findCachedFromFilePath(filePath, PRETTIER_INDEX_PATH);
 
-var PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js');
-
-var getGlobalPrettierPath = function getGlobalPrettierPath() {
-  return findCached(globalModules, PRETTIER_INDEX_PATH) || findCached(yarnGlobalModules, PRETTIER_INDEX_PATH);
-};
-
-var getLocalPrettierPath = function getLocalPrettierPath(filePath) {
-  return findCachedFromFilePath(filePath, PRETTIER_INDEX_PATH);
-};
-
-var getLocalOrGlobalPrettierPath = function getLocalOrGlobalPrettierPath(filePath) {
-  return getLocalPrettierPath(filePath) || getGlobalPrettierPath();
-};
+const getLocalOrGlobalPrettierPath = filePath => getLocalPrettierPath(filePath) || getGlobalPrettierPath();
 
 module.exports = {
-  getGlobalPrettierPath: getGlobalPrettierPath,
-  getLocalPrettierPath: getLocalPrettierPath,
-  getLocalOrGlobalPrettierPath: getLocalOrGlobalPrettierPath
+  getGlobalPrettierPath,
+  getLocalPrettierPath,
+  getLocalOrGlobalPrettierPath
 };

--- a/dist/helpers/index.js
+++ b/dist/helpers/index.js
@@ -6,10 +6,10 @@ var _extends3 = _interopRequireDefault(_extends2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var getPrettierInstance = require('./getPrettierInstance');
-var general = require('./general');
-var atomRelated = require('./atomRelated');
+const getPrettierInstance = require('./getPrettierInstance');
+const general = require('./general');
+const atomRelated = require('./atomRelated');
 
 module.exports = (0, _extends3.default)({}, general, atomRelated, {
-  getPrettierInstance: getPrettierInstance
+  getPrettierInstance
 });

--- a/dist/linterInterface/index.js
+++ b/dist/linterInterface/index.js
@@ -6,42 +6,35 @@ var _stringify2 = _interopRequireDefault(_stringify);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var _require = require('../editorInterface'),
-    getCurrentFilePath = _require.getCurrentFilePath;
+const { getCurrentFilePath } = require('../editorInterface');
 
 // Holds a reference to an IndieDelegate from the linter package. Used for displaying syntax errors
 // See: http://steelbrain.me/linter/types/indie-linter-v2.html
+let indieDelegate = null;
 
-
-var indieDelegate = null;
-
-var set = function set(newIndieDelegate) {
+const set = newIndieDelegate => {
   indieDelegate = newIndieDelegate;
 };
 
-var get = function get() {
-  return indieDelegate;
-};
+const get = () => indieDelegate;
 
-var setMessages = function setMessages(editor, messages) {
-  var filePath = getCurrentFilePath(editor);
+const setMessages = (editor, messages) => {
+  const filePath = getCurrentFilePath(editor);
 
   if (!indieDelegate || !filePath) {
     // eslint-disable-next-line
-    console.error('prettier-atom attempted to set messages with linter package, but was unable. Messages: ' + (0, _stringify2.default)(messages));
+    console.error(`prettier-atom attempted to set messages with linter package, but was unable. Messages: ${(0, _stringify2.default)(messages)}`);
     return;
   }
 
   indieDelegate.setMessages(filePath, messages);
 };
 
-var clearLinterErrors = function clearLinterErrors(editor) {
-  return setMessages(editor, []);
-};
+const clearLinterErrors = editor => setMessages(editor, []);
 
 module.exports = {
-  set: set,
-  get: get,
-  clearLinterErrors: clearLinterErrors,
-  setMessages: setMessages
+  set,
+  get,
+  clearLinterErrors,
+  setMessages
 };

--- a/dist/manualFormat/index.js
+++ b/dist/manualFormat/index.js
@@ -1,32 +1,16 @@
 'use strict';
 
-var _ = require('lodash/fp');
+const _ = require('lodash/fp');
+const { executePrettierOnBufferRange, executePrettierOnEmbeddedScripts } = require('../executePrettier');
+const { getBufferRange, isCurrentScopeEmbeddedScope } = require('../editorInterface');
+const { clearLinterErrors } = require('../linterInterface');
 
-var _require = require('../executePrettier'),
-    executePrettierOnBufferRange = _require.executePrettierOnBufferRange,
-    executePrettierOnEmbeddedScripts = _require.executePrettierOnEmbeddedScripts;
+const hasSelectedText = editor => !!editor.getSelectedText();
 
-var _require2 = require('../editorInterface'),
-    getBufferRange = _require2.getBufferRange,
-    isCurrentScopeEmbeddedScope = _require2.isCurrentScopeEmbeddedScope;
+const formatSelectedBufferRanges = editor => editor.getSelectedBufferRanges().forEach(bufferRange => executePrettierOnBufferRange(editor, bufferRange));
 
-var _require3 = require('../linterInterface'),
-    clearLinterErrors = _require3.clearLinterErrors;
+const executePrettierOnCurrentBufferRange = editor => executePrettierOnBufferRange(editor, getBufferRange(editor));
 
-var hasSelectedText = function hasSelectedText(editor) {
-  return !!editor.getSelectedText();
-};
-
-var formatSelectedBufferRanges = function formatSelectedBufferRanges(editor) {
-  return editor.getSelectedBufferRanges().forEach(function (bufferRange) {
-    return executePrettierOnBufferRange(editor, bufferRange);
-  });
-};
-
-var executePrettierOnCurrentBufferRange = function executePrettierOnCurrentBufferRange(editor) {
-  return executePrettierOnBufferRange(editor, getBufferRange(editor));
-};
-
-var format = _.flow(_.tap(clearLinterErrors), _.cond([[hasSelectedText, formatSelectedBufferRanges], [isCurrentScopeEmbeddedScope, executePrettierOnEmbeddedScripts], [_.stubTrue, executePrettierOnCurrentBufferRange]]));
+const format = _.flow(_.tap(clearLinterErrors), _.cond([[hasSelectedText, formatSelectedBufferRanges], [isCurrentScopeEmbeddedScope, executePrettierOnEmbeddedScripts], [_.stubTrue, executePrettierOnCurrentBufferRange]]));
 
 module.exports = format;

--- a/dist/statusTile/createStatusTile.js
+++ b/dist/statusTile/createStatusTile.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var getFormatOnSaveStatus = require('./getFormatOnSaveStatus');
+const getFormatOnSaveStatus = require('./getFormatOnSaveStatus');
+const { toggleFormatOnSave } = require('../atomInterface');
 
-var _require = require('../atomInterface'),
-    toggleFormatOnSave = _require.toggleFormatOnSave;
-
-var createStatusTile = function createStatusTile() {
-  var element = document.createElement('div');
-  var prettierTextNode = document.createTextNode('Prettier');
+const createStatusTile = () => {
+  const element = document.createElement('div');
+  const prettierTextNode = document.createTextNode('Prettier');
 
   element.appendChild(prettierTextNode);
   element.classList.add('prettier-status-tile');

--- a/dist/statusTile/getFormatOnSaveStatus.js
+++ b/dist/statusTile/getFormatOnSaveStatus.js
@@ -1,10 +1,7 @@
 'use strict';
 
-var _require = require('../atomInterface'),
-    isFormatOnSaveEnabled = _require.isFormatOnSaveEnabled;
+const { isFormatOnSaveEnabled } = require('../atomInterface');
 
-var getFormatOnSaveStatus = function getFormatOnSaveStatus() {
-  return isFormatOnSaveEnabled() ? 'enabled' : 'disabled';
-};
+const getFormatOnSaveStatus = () => isFormatOnSaveEnabled() ? 'enabled' : 'disabled';
 
 module.exports = getFormatOnSaveStatus;

--- a/dist/statusTile/index.js
+++ b/dist/statusTile/index.js
@@ -1,15 +1,13 @@
 'use strict';
 
-var createStatusTile = require('./createStatusTile');
-var updateStatusTile = require('./updateStatusTile');
-var updateStatusTileScope = require('./updateStatusTileScope');
-
-var _require = require('./tooltip'),
-    disposeTooltip = _require.disposeTooltip;
+const createStatusTile = require('./createStatusTile');
+const updateStatusTile = require('./updateStatusTile');
+const updateStatusTileScope = require('./updateStatusTileScope');
+const { disposeTooltip } = require('./tooltip');
 
 module.exports = {
-  createStatusTile: createStatusTile,
-  updateStatusTile: updateStatusTile,
-  updateStatusTileScope: updateStatusTileScope,
-  disposeTooltip: disposeTooltip
+  createStatusTile,
+  updateStatusTile,
+  updateStatusTileScope,
+  disposeTooltip
 };

--- a/dist/statusTile/tooltip.js
+++ b/dist/statusTile/tooltip.js
@@ -1,16 +1,14 @@
 "use strict";
 
-var tooltip = null;
+let tooltip = null;
 
-var disposeTooltip = function disposeTooltip() {
-  return tooltip && tooltip.dispose;
-};
+const disposeTooltip = () => tooltip && tooltip.dispose;
 
-var setTooltip = function setTooltip(nextTooltip) {
+const setTooltip = nextTooltip => {
   tooltip = nextTooltip;
 };
 
 module.exports = {
-  disposeTooltip: disposeTooltip,
-  setTooltip: setTooltip
+  disposeTooltip,
+  setTooltip
 };

--- a/dist/statusTile/updateStatusTile.js
+++ b/dist/statusTile/updateStatusTile.js
@@ -1,21 +1,16 @@
 'use strict';
 
-var _require = require('./tooltip'),
-    disposeTooltip = _require.disposeTooltip,
-    setTooltip = _require.setTooltip;
+const { disposeTooltip, setTooltip } = require('./tooltip');
+const getFormatOnSaveStatus = require('./getFormatOnSaveStatus');
+const { addTooltip } = require('../atomInterface');
 
-var getFormatOnSaveStatus = require('./getFormatOnSaveStatus');
-
-var _require2 = require('../atomInterface'),
-    addTooltip = _require2.addTooltip;
-
-var updateStatusTile = function updateStatusTile(disposable, element) {
+const updateStatusTile = (disposable, element) => {
   disposeTooltip();
 
   element.dataset.prettierFormatOnSave = getFormatOnSaveStatus(); // eslint-disable-line no-param-reassign
 
-  var newTooltip = addTooltip(element, {
-    title: 'Format on Save: ' + getFormatOnSaveStatus() + '<br>Click to toggle'
+  const newTooltip = addTooltip(element, {
+    title: `Format on Save: ${getFormatOnSaveStatus()}<br>Click to toggle`
   });
 
   setTooltip(newTooltip);

--- a/dist/statusTile/updateStatusTileScope.js
+++ b/dist/statusTile/updateStatusTileScope.js
@@ -1,12 +1,9 @@
 'use strict';
 
-var _require = require('../editorInterface'),
-    getCurrentScope = _require.getCurrentScope;
+const { getCurrentScope } = require('../editorInterface');
+const { getAllScopes } = require('../atomInterface');
 
-var _require2 = require('../atomInterface'),
-    getAllScopes = _require2.getAllScopes;
-
-var updateStatusTileScope = function updateStatusTileScope(element, editor) {
+const updateStatusTileScope = (element, editor) => {
   // The editor can be undefined if there is no active editor (e.g. closed all tabs).
   // eslint-disable-next-line no-param-reassign
   element.dataset.prettierMatchScope = editor && getAllScopes().includes(getCurrentScope(editor)) ? 'true' : 'false';

--- a/dist/warnAboutLinterEslintFixOnSave/index.js
+++ b/dist/warnAboutLinterEslintFixOnSave/index.js
@@ -1,19 +1,12 @@
 'use strict';
 
-var _require = require('../atomInterface'),
-    shouldUseEslint = _require.shouldUseEslint,
-    isLinterEslintAutofixEnabled = _require.isLinterEslintAutofixEnabled,
-    addWarningNotification = _require.addWarningNotification;
+const { shouldUseEslint, isLinterEslintAutofixEnabled, addWarningNotification } = require('../atomInterface');
 
-var MESSAGE = "prettier-atom: linter-eslint's `Fix on Save` feature is currently enabled. " + 'We recommend disabling this feature when using the ESlint integration from prettier-atom';
-var OPTIONS = { dismissable: true };
+const MESSAGE = "prettier-atom: linter-eslint's `Fix on Save` feature is currently enabled. " + 'We recommend disabling this feature when using the ESlint integration from prettier-atom';
+const OPTIONS = { dismissable: true };
 
-var displayWarning = function displayWarning() {
-  return addWarningNotification(MESSAGE, OPTIONS);
-};
+const displayWarning = () => addWarningNotification(MESSAGE, OPTIONS);
 
-var warnAboutLinterEslintFixOnSave = function warnAboutLinterEslintFixOnSave() {
-  return shouldUseEslint() && isLinterEslintAutofixEnabled() && displayWarning();
-};
+const warnAboutLinterEslintFixOnSave = () => shouldUseEslint() && isLinterEslintAutofixEnabled() && displayWarning();
 
 module.exports = warnAboutLinterEslintFixOnSave;


### PR DESCRIPTION
`babel-preset-env` tells babels your target environment so it can selectively apply polyfills and transforms.

`prettier-atom` has an `env` section in its `.babelrc`, but it is misconfigured.

**Before (Broken)**

```json
{
  "presets": [["env", { "electron": 1.4 }], "stage-2"],
  "plugins": ["transform-flow-strip-types", "transform-runtime"]
}
```

**After (Fixed)**
```json
{
  "presets": [["env", { "targets": { "electron": "1.4" } }], "stage-2"],
  "plugins": ["transform-flow-strip-types", "transform-runtime"]
}
```

In the previous version, the `targets` section was missing and the `electron` version was declared as a Float, which cannot be parsed.

This PR fixes the env to use the [correct api](https://github.com/babel/babel-preset-env/blob/master/test/fixtures/preset-options/electron/options.json).

Turns out there's a lot of stuff that babel does not need to worry about in `electron@1.4.0` as opposed to regular ES5. The size of the dist folder has reduced from `62kb` to `49kb`. 

![image](https://user-images.githubusercontent.com/1745854/38764614-86819c16-3f80-11e8-93b9-55c2bed37607.png)

![image](https://user-images.githubusercontent.com/1745854/38764598-2da81c46-3f80-11e8-87a8-7e8899b8f079.png)

Hopefully this bundle will be much better optimized for electron and speed things up 😊 .