### PR TITLE
fix(prettierignore): properly ignore files again

### DIFF
--- a/dist/helpers/isFileFormattable.js
+++ b/dist/helpers/isFileFormattable.js
@@ -3,10 +3,16 @@
 const _ = require('lodash/fp');
 const getPrettierInstance = require('./getPrettierInstance');
 const { getCurrentFilePath, isCurrentFilePathDefined } = require('../editorInterface');
+const { findCachedFromFilePath } = require('./general');
+
+const getNearestPrettierignorePath = filePath => findCachedFromFilePath(filePath, '.prettierignore');
 
 const getPrettierFileInfoForCurrentFilePath = (editor
 // $FlowFixMe: getFileInfo.sync needs to be addded to flow-typed
-) => getPrettierInstance(editor).getFileInfo.sync(getCurrentFilePath(editor), {}, '.prettierignore');
+) => getPrettierInstance(editor).getFileInfo.sync(getCurrentFilePath(editor), {
+  // $FlowIssue: we know filepath is defined at this point
+  ignorePath: getNearestPrettierignorePath(getCurrentFilePath(editor))
+});
 
 const doesFileInfoIndicateFormattable = fileInfo => fileInfo && !fileInfo.ignored && !!fileInfo.inferredParser;
 

--- a/src/helpers/isFileFormattable.js
+++ b/src/helpers/isFileFormattable.js
@@ -2,10 +2,17 @@
 const _ = require('lodash/fp');
 const getPrettierInstance = require('./getPrettierInstance');
 const { getCurrentFilePath, isCurrentFilePathDefined } = require('../editorInterface');
+const { findCachedFromFilePath } = require('./general');
+
+const getNearestPrettierignorePath = (filePath: FilePath): ?FilePath =>
+  findCachedFromFilePath(filePath, '.prettierignore');
 
 const getPrettierFileInfoForCurrentFilePath = (editor: TextEditor): Prettier$FileInfo =>
   // $FlowFixMe: getFileInfo.sync needs to be addded to flow-typed
-  getPrettierInstance(editor).getFileInfo.sync(getCurrentFilePath(editor), {}, '.prettierignore');
+  getPrettierInstance(editor).getFileInfo.sync(getCurrentFilePath(editor), {
+    // $FlowIssue: we know filepath is defined at this point
+    ignorePath: getNearestPrettierignorePath(getCurrentFilePath(editor)),
+  });
 
 const doesFileInfoIndicateFormattable = (fileInfo: Prettier$FileInfo): boolean =>
   fileInfo && !fileInfo.ignored && !!fileInfo.inferredParser;

--- a/src/helpers/isFileFormattable.test.js
+++ b/src/helpers/isFileFormattable.test.js
@@ -1,16 +1,19 @@
 jest.mock('./getPrettierInstance');
 jest.mock('../editorInterface');
+jest.mock('./general');
 
 const isFileFormattable = require('./isFileFormattable');
 const buildMockEditor = require('../../tests/mocks/textEditor');
 const getPrettierInstance = require('./getPrettierInstance');
 const { getCurrentFilePath, isCurrentFilePathDefined } = require('../editorInterface');
+const { findCachedFromFilePath } = require('./general');
 
 const mockEditor = buildMockEditor();
 
 beforeEach(() => {
   isCurrentFilePathDefined.mockImplementation(() => true);
   getCurrentFilePath.mockImplementation(() => 'xyz.js');
+  findCachedFromFilePath.mockImplementation(() => '.prettierignore');
 });
 
 const mockGetFileInfoSyncFunc = syncFunc =>
@@ -23,7 +26,7 @@ it('calls prettier.getFileInfo.sync with the proper arguments', () => {
 
   isFileFormattable(mockEditor);
 
-  expect(sync).toHaveBeenCalledWith('xyz.js', {}, '.prettierignore');
+  expect(sync).toHaveBeenCalledWith('xyz.js', { ignorePath: '.prettierignore' });
 });
 
 it('returns true if the file is formattable', () => {


### PR DESCRIPTION
PR #404 changed to using Prettier's `getFileInfo` and `resolveConfig` functions to determine
whether a file is formattable. We were not correctly invoking the API for `getFileInfo` so every
file was coming up as not ignored.

Fixes #446