### PR TITLE
fix: ensure we always pass a relative path to `ignore` pkg

### DIFF
--- a/dist/atomInterface/index.js
+++ b/dist/atomInterface/index.js
@@ -6,6 +6,7 @@ var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+const path = require('path');
 const _ = require('lodash/fp');
 
 // constants
@@ -70,7 +71,12 @@ const attemptWithErrorNotification = (() => {
 
 const runLinter = editor => isLinterLintCommandDefined(editor) && atom.commands.dispatch(atom.views.getView(editor), LINTER_LINT_COMMAND);
 
-const relativizePathFromAtomProject = path => path ? _.get('[1]', atom.project.relativizePath(path)) : null;
+const invokeAtomRelativizePath = _.flow(filePath => atom.project.relativizePath(filePath), // NOTE: fat arrow necessary for `this`
+_.get('[1]'));
+
+const relativizePathToDirname = filePath => path.relative(path.dirname(filePath), filePath);
+
+const relativizePathFromAtomProject = _.cond([[_.isNil, _.constant(null)], [_.flow(invokeAtomRelativizePath, path.isAbsolute), relativizePathToDirname], [_.stubTrue, invokeAtomRelativizePath]]);
 
 module.exports = {
   addErrorNotification,

--- a/src/atomInterface/index.test.js
+++ b/src/atomInterface/index.test.js
@@ -4,9 +4,42 @@ const {
   shouldUseStylelint,
   getPrettierEslintOptions,
   isLinterEslintAutofixEnabled,
+  relativizePathFromAtomProject,
   toggleFormatOnSave,
 } = require('./index');
 const textEditor = require('../../tests/mocks/textEditor');
+
+describe('relativizePathFromAtomProject()', () => {
+  it('runs `atom.project.relativizePath` if the filepath and project are present', () => {
+    const absoluteFilePath = '/Users/johndoe/src/main.js';
+    const relativeFilePath = 'main.js';
+    atom = { project: { relativizePath: jest.fn(() => [null, relativeFilePath]) } };
+
+    const actual = relativizePathFromAtomProject(absoluteFilePath);
+
+    expect(actual).toEqual(relativeFilePath);
+    expect(atom.project.relativizePath).toHaveBeenCalledWith(absoluteFilePath);
+  });
+
+  it('relativizes the path to the parent dir if the filepath is present but project is missing', () => {
+    const absoluteFilePath = '/Users/johndoe/src/main.js';
+    const relativeFilePath = 'main.js';
+    atom = { project: { relativizePath: jest.fn(() => [null, absoluteFilePath]) } };
+
+    const actual = relativizePathFromAtomProject(absoluteFilePath);
+
+    expect(actual).toEqual(relativeFilePath);
+    expect(atom.project.relativizePath).toHaveBeenCalledWith(absoluteFilePath);
+  });
+
+  it('returns null if no filepath is present', () => {
+    const filePath = null;
+
+    const actual = relativizePathFromAtomProject(filePath);
+
+    expect(actual).toEqual(null);
+  });
+});
 
 describe('runLinter()', () => {
   it('runs `linter:lint` command', () => {


### PR DESCRIPTION
`atom.project.relativizePath` returns an absolute path when no Atom project can be determined (such
as when editing your Atom config file and many other cases). The `ignore` package will then
hard-error because it is now very strict about getting only relative paths (they assume that the
filenames we are comparing the globs to should be relative to the file in which the globs live, but
we actually hold the globs in the prettier-atom options so this concept doesn't really apply so we
just arbitrarily choose to make relativize paths from the project's root dir). To fix, we relativize
to the parent dir of the file, which is somewhat arbitrary but should be fine.

Fixes #473