### PR TITLE
defer activating the package until the window is loaded.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/prettier/prettier-atom/issues"
   },
   "license": "MIT",
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "dependencies": {
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.6.2",


### PR DESCRIPTION
Using the latest version of atom (1.34.0 at this time), this package is consistently the slowest to activate. I've recorded the average activation time for this package in two scenarios;

1. A window with one project open and reloaded 4 times: average activation time is 321ms
2. A window with no project open and reloaded 4 times: average activation time is 222ms

Using this activation hook, atom will defer activating this package until the window is ready to use and then there's no impact to startup time. Since this package doesn't need to do heavy setup, I think it should wait as long as possible to activate anyway.