### PR TITLE
Cleanup of lazy loading code

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,73 +1,24 @@
 'use strict';
 
-var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
-
-var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 const { CompositeDisposable } = require('atom');
 const config = require('./config-schema.json');
 const { createStatusTile, updateStatusTile, updateStatusTileScope, disposeTooltip } = require('./statusTile');
 const linterInterface = require('./linterInterface');
+const format = require('./manualFormat'); // eslint-disable-line global-require
+const formatOnSave = require('./formatOnSave'); // eslint-disable-line global-require
+// eslint-disable-next-line global-require
+const warnAboutLinterEslintFixOnSave = require('./warnAboutLinterEslintFixOnSave');
+// eslint-disable-next-line global-require
+const displayDebugInfo = require('./displayDebugInfo');
+// eslint-disable-next-line global-require,prefer-destructuring
+const toggleFormatOnSave = require('./atomInterface').toggleFormatOnSave;
 
 // local helpers
-let format = null;
-let formatOnSave = null;
-let warnAboutLinterEslintFixOnSave = null;
-let displayDebugInfo = null;
-let toggleFormatOnSave = null;
 let subscriptions = null;
 let statusBarHandler = null;
 let statusBarTile = null;
 let tileElement = null;
-
-// HACK: lazy load most of the code we need for performance
-const lazyFormat = () => {
-  if (!format) format = require('./manualFormat'); // eslint-disable-line global-require
-
-  const editor = atom.workspace.getActiveTextEditor();
-  if (editor) format(editor);
-};
-
-// HACK: lazy load most of the code we need for performance
-const lazyFormatOnSave = (() => {
-  var _ref = (0, _asyncToGenerator3.default)(function* (editor) {
-    if (!formatOnSave) formatOnSave = require('./formatOnSave'); // eslint-disable-line global-require
-    if (editor) yield formatOnSave(editor);
-  });
-
-  return function lazyFormatOnSave(_x) {
-    return _ref.apply(this, arguments);
-  };
-})();
-
-// HACK: lazy load most of the code we need for performance
-const lazyWarnAboutLinterEslintFixOnSave = () => {
-  if (!warnAboutLinterEslintFixOnSave) {
-    // eslint-disable-next-line global-require
-    warnAboutLinterEslintFixOnSave = require('./warnAboutLinterEslintFixOnSave');
-  }
-  warnAboutLinterEslintFixOnSave();
-};
-
-// HACK: lazy load most of the code we need for performance
-const lazyDisplayDebugInfo = () => {
-  if (!displayDebugInfo) {
-    // eslint-disable-next-line global-require
-    displayDebugInfo = require('./displayDebugInfo');
-  }
-  displayDebugInfo();
-};
-
-const lazyToggleFormatOnSave = () => {
-  if (!toggleFormatOnSave) {
-    // eslint-disable-next-line global-require,prefer-destructuring
-    toggleFormatOnSave = require('./atomInterface').toggleFormatOnSave;
-  }
-  toggleFormatOnSave();
-};
 
 const attachStatusTile = () => {
   if (statusBarHandler) {
@@ -104,14 +55,10 @@ const activate = () => {
 
   subscriptions = new CompositeDisposable();
 
-  subscriptions.add(atom.commands.add('atom-workspace', 'prettier:format', lazyFormat));
-  subscriptions.add(atom.commands.add('atom-workspace', 'prettier:debug', lazyDisplayDebugInfo));
-  subscriptions.add(atom.commands.add('atom-workspace', 'prettier:toggle-format-on-save', lazyToggleFormatOnSave));
-
-  subscriptions.add(atom.workspace.observeTextEditors(editor => subscriptions.add(editor.getBuffer().onWillSave(() => lazyFormatOnSave(editor)))));
-  subscriptions.add(atom.config.observe('linter-eslint.fixOnSave', () => lazyWarnAboutLinterEslintFixOnSave()));
-  subscriptions.add(atom.config.observe('prettier-atom.useEslint', () => lazyWarnAboutLinterEslintFixOnSave()));
-  subscriptions.add(atom.config.observe('prettier-atom.formatOnSaveOptions.showInStatusBar', show => show ? attachStatusTile() : detachStatusTile()));
+  subscriptions.add(atom.commands.add('atom-workspace', 'prettier:format', () => {
+    const editor = atom.workspace.getActiveTextEditor();
+    if (editor) format(editor);
+  }), atom.commands.add('atom-workspace', 'prettier:debug', displayDebugInfo), atom.commands.add('atom-workspace', 'prettier:toggle-format-on-save', toggleFormatOnSave), atom.workspace.observeTextEditors(editor => subscriptions.add(editor.getBuffer().onWillSave(() => editor && formatOnSave(editor)))), atom.config.observe('linter-eslint.fixOnSave', warnAboutLinterEslintFixOnSave), atom.config.observe('prettier-atom.useEslint', warnAboutLinterEslintFixOnSave), atom.config.observe('prettier-atom.formatOnSaveOptions.showInStatusBar', show => show ? attachStatusTile() : detachStatusTile()));
 
   // HACK: an Atom bug seems to be causing old configuration settings to linger for some users
   //       https://github.com/prettier/prettier-atom/issues/72


### PR DESCRIPTION
After further profiling of the `activate` function, I realized it still took ~300ms, which is alright when it's deferred. After removing the lazy loading wrappers and combining those `subscriptions.add` calls into one, I shaved off >100ms, which is further improvement.

`loadPackageDeps` is the bottleneck now. It's accounting for over 100ms while the rest of the activation is about 15ms.

Is the linter package a hard dependency? I'd suggest deferring the check for it until after activation or during the `initialize` phase of the package because the service consumption happens whenever the providing package is activated. So prettier-atom can activate independently, and a user can install linter much later on and automatically see the messages from this package.