### PR TITLE
fix(prettierignore): Revert mistake with path passed to prettier.getFileInfo

### DIFF
--- a/dist/helpers/isFileFormattable.js
+++ b/dist/helpers/isFileFormattable.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const _ = require('lodash/fp');
 const getPrettierInstance = require('./getPrettierInstance');
 const { shouldIgnoreNodeModules } = require('../atomInterface');
@@ -9,17 +8,9 @@ const { findCachedFromFilePath } = require('./general');
 
 const getNearestPrettierignorePath = filePath => findCachedFromFilePath(filePath, '.prettierignore');
 
-const getNearestPrettierignoreParentDirPathRelativeToCurrentFilePath = editor => {
-  // $FlowIssue: we know filepath is defined at this point
-  const filePath = getCurrentFilePath(editor);
-  const nearestPrettierignorePath = getNearestPrettierignorePath(filePath);
-
-  return nearestPrettierignorePath ? path.relative(path.dirname(nearestPrettierignorePath), filePath) : filePath;
-};
-
 const getPrettierFileInfoForCurrentFilePath = (editor
 // $FlowFixMe: getFileInfo.sync needs to be addded to flow-typed
-) => getPrettierInstance(editor).getFileInfo.sync(getNearestPrettierignoreParentDirPathRelativeToCurrentFilePath(editor), {
+) => getPrettierInstance(editor).getFileInfo.sync(getCurrentFilePath(editor), {
   withNodeModules: !shouldIgnoreNodeModules(),
   // $FlowIssue: we know filepath is defined at this point
   ignorePath: getNearestPrettierignorePath(getCurrentFilePath(editor))

--- a/src/helpers/isFileFormattable.js
+++ b/src/helpers/isFileFormattable.js
@@ -1,5 +1,4 @@
 // @flow
-const path = require('path');
 const _ = require('lodash/fp');
 const getPrettierInstance = require('./getPrettierInstance');
 const { shouldIgnoreNodeModules } = require('../atomInterface');
@@ -9,26 +8,13 @@ const { findCachedFromFilePath } = require('./general');
 const getNearestPrettierignorePath = (filePath: FilePath): ?FilePath =>
   findCachedFromFilePath(filePath, '.prettierignore');
 
-const getCurrentFilePathRelativeToNearestPrettierignoreParentDir = (editor: TextEditor): string => {
-  // $FlowIssue: we know filepath is defined at this point
-  const filePath: string = getCurrentFilePath(editor);
-  const nearestPrettierignorePath = getNearestPrettierignorePath(filePath);
-
-  return nearestPrettierignorePath
-    ? path.relative(path.dirname(nearestPrettierignorePath), filePath)
-    : filePath;
-};
-
 const getPrettierFileInfoForCurrentFilePath = (editor: TextEditor): Prettier$FileInfo =>
   // $FlowFixMe: getFileInfo.sync needs to be addded to flow-typed
-  getPrettierInstance(editor).getFileInfo.sync(
-    getCurrentFilePathRelativeToNearestPrettierignoreParentDir(editor),
-    {
-      withNodeModules: !shouldIgnoreNodeModules(),
-      // $FlowIssue: we know filepath is defined at this point
-      ignorePath: getNearestPrettierignorePath(getCurrentFilePath(editor)),
-    },
-  );
+  getPrettierInstance(editor).getFileInfo.sync(getCurrentFilePath(editor), {
+    withNodeModules: !shouldIgnoreNodeModules(),
+    // $FlowIssue: we know filepath is defined at this point
+    ignorePath: getNearestPrettierignorePath(getCurrentFilePath(editor)),
+  });
 
 const doesFileInfoIndicateFormattable = (fileInfo: Prettier$FileInfo): boolean =>
   fileInfo && !fileInfo.ignored && !!fileInfo.inferredParser;


### PR DESCRIPTION
This is really embarrassing, but my PR #498 broke ignores instead of fixing them. It appeared to fix it on my side, however I'm now retesting from master; it's definitely broken and reverting my change definitely fixes it. Something might've been wrong with my dev env or .prettierignore, either way I goofed somehow. Sorry for the trouble! 😅