### PR TITLE
fix(debug): read-pkg-up@6 renamed pkg to package

### DIFF
--- a/dist/displayDebugInfo/index.js
+++ b/dist/displayDebugInfo/index.js
@@ -18,7 +18,7 @@ const getDepPath = dep => path.join(__dirname, '..', '..', 'node_modules', dep);
 
 const getPackageInfo = dir => readPkgUp.sync({
   cwd: dir
-}).pkg;
+})["package"];
 
 const getDebugInfo = () => {
   const globalPrettierPath = getGlobalPrettierPath();

--- a/dist/displayDebugInfo/index.test.js
+++ b/dist/displayDebugInfo/index.test.js
@@ -26,7 +26,7 @@ test('it displays a notification on Atom with package information', () => {
     options = _options;
   });
   readPkgUp.sync.mockImplementation(() => ({
-    pkg: {
+    "package": {
       version: 'FAKE_PACKAGE_VERSION'
     }
   }));

--- a/src/displayDebugInfo/index.js
+++ b/src/displayDebugInfo/index.js
@@ -6,7 +6,7 @@ const { getGlobalPrettierPath } = require('../helpers/getPrettierPath');
 
 const getDepPath = (dep: string) => path.join(__dirname, '..', '..', 'node_modules', dep);
 
-const getPackageInfo = (dir: string) => readPkgUp.sync({ cwd: dir }).pkg;
+const getPackageInfo = (dir: string) => readPkgUp.sync({ cwd: dir }).package;
 
 const getDebugInfo = () => {
   const globalPrettierPath = getGlobalPrettierPath();

--- a/src/displayDebugInfo/index.test.js
+++ b/src/displayDebugInfo/index.test.js
@@ -15,7 +15,7 @@ test('it displays a notification on Atom with package information', () => {
     options = _options;
   });
   readPkgUp.sync.mockImplementation(() => ({
-    pkg: {
+    package: {
       version: 'FAKE_PACKAGE_VERSION',
     },
   }));


### PR DESCRIPTION
BC break on read-pkg-up@6, renamed { pkg: ...} to { package: ...}
https://github.com/sindresorhus/read-pkg-up/releases/tag/v6.0.0

fixes #508