### PR TITLE
fix(global-prettier-resolution): add fallback for NVM users

### DIFF
--- a/dist/helpers/getPrettierPath.js
+++ b/dist/helpers/getPrettierPath.js
@@ -3,8 +3,16 @@
 const path = require('path');
 
 const {
+  sync: execaSync
+} = require('execa');
+
+const {
   findCached
 } = require('atom-linter');
+
+const {
+  memoize
+} = require('lodash');
 
 const globalModules = require('global-modules');
 
@@ -14,9 +22,28 @@ const {
   findCachedFromFilePath
 } = require('./general');
 
-const PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js');
+const PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js'); // global-prefix package (which is used by global-modules) fails
+// to locate the directory if Node and NPM are installed via NVM
+// https://github.com/jonschlinkert/global-prefix/issues/19
+// The function below applies a fallback search mechanism,
+// which relies on calling 'npm get prefix'
 
-const getGlobalPrettierPath = () => findCached(globalModules, PRETTIER_INDEX_PATH) || findCached(yarnGlobalModules, PRETTIER_INDEX_PATH);
+const getFallbackGlobalModulesPath = memoize(() => {
+  try {
+    const prefix = execaSync('npm', ['get', 'prefix']).stdout; // Inspired by global-modules
+    // https://github.com/jonschlinkert/global-modules/blob/7455e827f0ce0366d224aea035a8fecd233aa24a/index.js
+
+    if (process.platform === 'win32' || process.env.OSTYPE === 'msys' || process.env.OSTYPE === 'cygwin') {
+      return path.resolve(prefix, 'node_modules');
+    }
+
+    return path.resolve(prefix, 'lib/node_modules');
+  } catch (e) {
+    return '';
+  }
+});
+
+const getGlobalPrettierPath = () => findCached(globalModules, PRETTIER_INDEX_PATH) || findCached(yarnGlobalModules, PRETTIER_INDEX_PATH) || findCached(getFallbackGlobalModulesPath(), PRETTIER_INDEX_PATH);
 
 const getLocalPrettierPath = filePath => findCachedFromFilePath(filePath, PRETTIER_INDEX_PATH);
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "atom-package-deps": "^5.1.0",
     "atom-text-buffer-point": "^1.0.0",
     "atom-text-buffer-range": "^1.0.0",
+    "execa": "^1.0.0",
     "global-modules": "^2.0.0",
     "ignore": "^5.1.2",
     "lodash": "^4.17.13",

--- a/src/helpers/getPrettierPath.js
+++ b/src/helpers/getPrettierPath.js
@@ -1,14 +1,38 @@
 // @flow
 const path = require('path');
+const { sync: execaSync } = require('execa');
 const { findCached } = require('atom-linter');
+const { memoize } = require('lodash');
 const globalModules = require('global-modules');
 const yarnGlobalModules = require('yarn-global-modules')();
 const { findCachedFromFilePath } = require('./general');
 
 const PRETTIER_INDEX_PATH = path.join('node_modules', 'prettier', 'index.js');
 
+// global-prefix package (which is used by global-modules) fails
+// to locate the directory if Node and NPM are installed via NVM
+// https://github.com/jonschlinkert/global-prefix/issues/19
+// The function below applies a fallback search mechanism,
+// which relies on calling 'npm get prefix'
+const getFallbackGlobalModulesPath = memoize(() => {
+  try {
+    const prefix = execaSync('npm', ['get', 'prefix']).stdout;
+
+    // Inspired by global-modules
+    // https://github.com/jonschlinkert/global-modules/blob/7455e827f0ce0366d224aea035a8fecd233aa24a/index.js
+    if (process.platform === 'win32' || process.env.OSTYPE === 'msys' || process.env.OSTYPE === 'cygwin') {
+      return path.resolve(prefix, 'node_modules');
+    }
+    return path.resolve(prefix, 'lib/node_modules');
+  } catch (e) {
+    return '';
+  }
+});
+
 const getGlobalPrettierPath = (): ?FilePath =>
-  findCached(globalModules, PRETTIER_INDEX_PATH) || findCached(yarnGlobalModules, PRETTIER_INDEX_PATH);
+  findCached(globalModules, PRETTIER_INDEX_PATH) ||
+  findCached(yarnGlobalModules, PRETTIER_INDEX_PATH) ||
+  findCached(getFallbackGlobalModulesPath(), PRETTIER_INDEX_PATH);
 
 const getLocalPrettierPath = (filePath: ?FilePath): ?FilePath =>
   findCachedFromFilePath(filePath, PRETTIER_INDEX_PATH);


### PR DESCRIPTION
Closes #448 

When Prettier is not found in the current project, the extension first attempts to find a global instance of it and finally falls back to the built-in instance. The second step is important for those who want to use Prettier with plugins, but does not want to see local `node_modules` in each project just because of it. Searching for global Prettier was added in https://github.com/prettier/prettier-atom/pull/397 by me; we use this feature in [litvis](https://github.com/gicentre/litvis#automatic-code-formatting).

Recently, my colleague @jwoLondon discovered that global Prettier does not get resolved when Node and NPM are installed via [NVM](https://github.com/nvm-sh/nvm). This setup method is pretty prevalent and is especially helpful when a user does not have admin rights (e.g. on managed company laptops and in education environments such as university labs).

We investigated the problem and discovered that it comes from [global-modules](https://www.npmjs.com/package/global-prefix), which does not work as reliably as the `npm get prefix` command. Related issues:

- https://github.com/jonschlinkert/global-prefix/issues/19
- https://github.com/jonschlinkert/global-prefix/issues/20
- https://github.com/jonschlinkert/global-prefix/issues/21

This PR introduces a fallback search mechanism for global node modules, which should at least help NVM users, but maybe solves the issue in other edge cases too. I tested it by creating a new macOS user, installing NVM and then running `npm install --global prettier prettier-plugin-elm`. Debug info no longer shows `prettier: bundled` – it is now `/Users/tester/.nvm/versions/node/v12.11.1/lib/node_modules/prettier/index.js`. Global plugins work! 🎉

I decided to add the fallback search method instead of replacing the existing one to make sure the fix is non-breaking. Hope it can land the next patch release soon and it is much needed at City, University of London this term!