### PR TITLE
feat: Add option to use configuration from `.editorconfig`

### DIFF
--- a/dist/atomInterface/index.js
+++ b/dist/atomInterface/index.js
@@ -26,6 +26,8 @@ const shouldUseEslint = () => getConfigOption('useEslint');
 
 const shouldUseStylelint = () => getConfigOption('useStylelint');
 
+const shouldUseEditorConfig = () => getConfigOption('useEditorConfig');
+
 const isFormatOnSaveEnabled = () => getConfigOption('formatOnSaveOptions.enabled');
 
 const isDisabledIfNotInPackageJson = () => getConfigOption('formatOnSaveOptions.isDisabledIfNotInPackageJson');
@@ -106,6 +108,7 @@ module.exports = {
   shouldRespectEslintignore,
   shouldUseEslint,
   shouldUseStylelint,
+  shouldUseEditorConfig,
   toggleFormatOnSave,
   attemptWithErrorNotification
 };

--- a/dist/config-schema.json
+++ b/dist/config-schema.json
@@ -1,19 +1,24 @@
 {
   "useEslint": {
     "title": "ESLint Integration",
-    "description":
-      "Use [prettier-eslint](https://github.com/prettier/prettier-eslint) to infer your Prettier settings based on your ESLint config and run eslint --fix after prettier formats the document. If we cannot infer a Prettier setting from your ESLint config (or if there is none in the current project), we will fallback to using your settings in the *Prettier Options* section.<br><br>**Note:** If you enable *Format on Save*, we recommend disabling ESlint's auto-fix to prevent fixing your code twice.",
+    "description": "Use [prettier-eslint](https://github.com/prettier/prettier-eslint) to infer your Prettier settings based on your ESLint config and run eslint --fix after prettier formats the document. If we cannot infer a Prettier setting from your ESLint config (or if there is none in the current project), we will fallback to using your settings in the *Prettier Options* section.<br><br>**Note:** If you enable *Format on Save*, we recommend disabling ESlint's auto-fix to prevent fixing your code twice.",
     "type": "boolean",
     "default": false,
     "order": 1
   },
   "useStylelint": {
     "title": "Stylelint Integration",
-    "description":
-      "Use [prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint) to infer your Prettier settings based on your Stylelint config. If we cannot infer a Prettier setting from your Stylelint config (or if there is none in the current project), we will fallback to using your settings in the *Prettier Options* section.",
+    "description": "Use [prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint) to infer your Prettier settings based on your Stylelint config. If we cannot infer a Prettier setting from your Stylelint config (or if there is none in the current project), we will fallback to using your settings in the *Prettier Options* section.",
     "type": "boolean",
     "default": false,
     "order": 2
+  },
+  "useEditorConfig": {
+    "title": "EditorConfig Integration",
+    "description": "Use [EditorConfig](https://editorconfig.org/) to infer your Prettier settings based on your `.editorconfig`",
+    "type": "boolean",
+    "default": true,
+    "order": 3
   },
   "formatOnSaveOptions": {
     "title": "Format on Save",
@@ -43,32 +48,28 @@
       },
       "excludedGlobs": {
         "title": "Exclude (list of globs)",
-        "description":
-          "A list of [.gitignore style](https://git-scm.com/docs/gitignore) file globs to exclude from formatting on save (takes precedence over scopes). Use commas to separate each glob.",
+        "description": "A list of [.gitignore style](https://git-scm.com/docs/gitignore) file globs to exclude from formatting on save (takes precedence over scopes). Use commas to separate each glob.",
         "type": "array",
         "default": [],
         "order": 4
       },
       "whitelistedGlobs": {
         "title": "Include (list of globs)",
-        "description":
-          "A list of [.gitignore style](https://git-scm.com/docs/gitignore) file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to separate each glob.<br><br>**Note:** If there are globs in this list, files not matching the globs will not be formatted on save, regardless of other options.",
+        "description": "A list of [.gitignore style](https://git-scm.com/docs/gitignore) file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to separate each glob.<br><br>**Note:** If there are globs in this list, files not matching the globs will not be formatted on save, regardless of other options.",
         "type": "array",
         "default": [],
         "order": 5
       },
       "isDisabledIfNotInPackageJson": {
         "title": "Only format if Prettier is found in your project's dependencies",
-        "description":
-          "Only format on save when `prettier` (or `prettier-eslint`/`prettier-eslint-cli` if using *ESLint integration*) is in your project's `package.json` (dependencies or devDependencies)",
+        "description": "Only format on save when `prettier` (or `prettier-eslint`/`prettier-eslint-cli` if using *ESLint integration*) is in your project's `package.json` (dependencies or devDependencies)",
         "type": "boolean",
         "default": false,
         "order": 6
       },
       "isDisabledIfNoConfigFile": {
         "title": "Only format if a Prettier config is found",
-        "description":
-          "Only format on save if we find a `.prettierrc` file (written in YAML or JSON), a `prettier.config.js` file that exports an object, or a 'prettier' key in your `package.json` file.",
+        "description": "Only format on save if we find a `.prettierrc` file (written in YAML or JSON), a `prettier.config.js` file that exports an object, or a 'prettier' key in your `package.json` file.",
         "type": "boolean",
         "default": false,
         "order": 7

--- a/dist/executePrettier/executePrettierOnBufferRange.js
+++ b/dist/executePrettier/executePrettierOnBufferRange.js
@@ -24,6 +24,7 @@ const {
   getPrettierEslintOptions,
   shouldUseEslint,
   shouldUseStylelint,
+  shouldUseEditorConfig,
   runLinter
 } = require('../atomInterface');
 
@@ -39,7 +40,9 @@ const {
 const handleError = require('./handleError');
 
 const getPrettierOptions = editor => // $FlowFixMe
-getPrettierInstance(editor).resolveConfig.sync(getCurrentFilePath(editor));
+getPrettierInstance(editor).resolveConfig.sync(getCurrentFilePath(editor), {
+  editorconfig: shouldUseEditorConfig()
+});
 
 const executePrettier = (editor, text) => // $FlowFixMe
 getPrettierInstance(editor).format(text, _objectSpread({

--- a/dist/executePrettier/executePrettierOnBufferRange.test.js
+++ b/dist/executePrettier/executePrettierOnBufferRange.test.js
@@ -28,6 +28,7 @@ const {
   getPrettierEslintOptions,
   shouldUseEslint,
   shouldUseStylelint,
+  shouldUseEditorConfig,
   runLinter
 } = require('../atomInterface');
 
@@ -75,6 +76,26 @@ beforeEach(() => {
   getPrettierInstance.mockImplementation(() => prettier);
   prettier.resolveConfig.sync.mockImplementation(() => optionsFixture);
 });
+it('uses editor config',
+/*#__PURE__*/
+(0, _asyncToGenerator2["default"])(function* () {
+  getCurrentFilePath.mockImplementation(() => 'foo.js');
+  shouldUseEditorConfig.mockImplementation(() => true);
+  yield executePrettierOnBufferRange(editor, bufferRangeFixture);
+  expect(prettier.resolveConfig.sync).toHaveBeenCalledWith('foo.js', {
+    editorconfig: true
+  });
+}));
+it('does not use editor config',
+/*#__PURE__*/
+(0, _asyncToGenerator2["default"])(function* () {
+  getCurrentFilePath.mockImplementation(() => 'foo.js');
+  shouldUseEditorConfig.mockImplementation(() => false);
+  yield executePrettierOnBufferRange(editor, bufferRangeFixture);
+  expect(prettier.resolveConfig.sync).toHaveBeenCalledWith('foo.js', {
+    editorconfig: false
+  });
+}));
 it('sets the transformed text in the buffer range',
 /*#__PURE__*/
 (0, _asyncToGenerator2["default"])(function* () {

--- a/src/atomInterface/index.js
+++ b/src/atomInterface/index.js
@@ -23,6 +23,8 @@ const shouldUseEslint = () => getConfigOption('useEslint');
 
 const shouldUseStylelint = () => getConfigOption('useStylelint');
 
+const shouldUseEditorConfig = () => getConfigOption('useEditorConfig');
+
 const isFormatOnSaveEnabled = () => getConfigOption('formatOnSaveOptions.enabled');
 
 const isDisabledIfNotInPackageJson = () =>
@@ -110,6 +112,7 @@ module.exports = {
   shouldRespectEslintignore,
   shouldUseEslint,
   shouldUseStylelint,
+  shouldUseEditorConfig,
   toggleFormatOnSave,
   attemptWithErrorNotification,
 };

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -1,19 +1,24 @@
 {
   "useEslint": {
     "title": "ESLint Integration",
-    "description":
-      "Use [prettier-eslint](https://github.com/prettier/prettier-eslint) to infer your Prettier settings based on your ESLint config and run eslint --fix after prettier formats the document. If we cannot infer a Prettier setting from your ESLint config (or if there is none in the current project), we will fallback to using your settings in the *Prettier Options* section.<br><br>**Note:** If you enable *Format on Save*, we recommend disabling ESlint's auto-fix to prevent fixing your code twice.",
+    "description": "Use [prettier-eslint](https://github.com/prettier/prettier-eslint) to infer your Prettier settings based on your ESLint config and run eslint --fix after prettier formats the document. If we cannot infer a Prettier setting from your ESLint config (or if there is none in the current project), we will fallback to using your settings in the *Prettier Options* section.<br><br>**Note:** If you enable *Format on Save*, we recommend disabling ESlint's auto-fix to prevent fixing your code twice.",
     "type": "boolean",
     "default": false,
     "order": 1
   },
   "useStylelint": {
     "title": "Stylelint Integration",
-    "description":
-      "Use [prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint) to infer your Prettier settings based on your Stylelint config. If we cannot infer a Prettier setting from your Stylelint config (or if there is none in the current project), we will fallback to using your settings in the *Prettier Options* section.",
+    "description": "Use [prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint) to infer your Prettier settings based on your Stylelint config. If we cannot infer a Prettier setting from your Stylelint config (or if there is none in the current project), we will fallback to using your settings in the *Prettier Options* section.",
     "type": "boolean",
     "default": false,
     "order": 2
+  },
+  "useEditorConfig": {
+    "title": "EditorConfig Integration",
+    "description": "Use [EditorConfig](https://editorconfig.org/) to infer your Prettier settings based on your `.editorconfig`",
+    "type": "boolean",
+    "default": true,
+    "order": 3
   },
   "formatOnSaveOptions": {
     "title": "Format on Save",
@@ -43,32 +48,28 @@
       },
       "excludedGlobs": {
         "title": "Exclude (list of globs)",
-        "description":
-          "A list of [.gitignore style](https://git-scm.com/docs/gitignore) file globs to exclude from formatting on save (takes precedence over scopes). Use commas to separate each glob.",
+        "description": "A list of [.gitignore style](https://git-scm.com/docs/gitignore) file globs to exclude from formatting on save (takes precedence over scopes). Use commas to separate each glob.",
         "type": "array",
         "default": [],
         "order": 4
       },
       "whitelistedGlobs": {
         "title": "Include (list of globs)",
-        "description":
-          "A list of [.gitignore style](https://git-scm.com/docs/gitignore) file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to separate each glob.<br><br>**Note:** If there are globs in this list, files not matching the globs will not be formatted on save, regardless of other options.",
+        "description": "A list of [.gitignore style](https://git-scm.com/docs/gitignore) file globs to always format on save (takes precedence over scopes and excluded globs). Use commas to separate each glob.<br><br>**Note:** If there are globs in this list, files not matching the globs will not be formatted on save, regardless of other options.",
         "type": "array",
         "default": [],
         "order": 5
       },
       "isDisabledIfNotInPackageJson": {
         "title": "Only format if Prettier is found in your project's dependencies",
-        "description":
-          "Only format on save when `prettier` (or `prettier-eslint`/`prettier-eslint-cli` if using *ESLint integration*) is in your project's `package.json` (dependencies or devDependencies)",
+        "description": "Only format on save when `prettier` (or `prettier-eslint`/`prettier-eslint-cli` if using *ESLint integration*) is in your project's `package.json` (dependencies or devDependencies)",
         "type": "boolean",
         "default": false,
         "order": 6
       },
       "isDisabledIfNoConfigFile": {
         "title": "Only format if a Prettier config is found",
-        "description":
-          "Only format on save if we find a `.prettierrc` file (written in YAML or JSON), a `prettier.config.js` file that exports an object, or a 'prettier' key in your `package.json` file.",
+        "description": "Only format on save if we find a `.prettierrc` file (written in YAML or JSON), a `prettier.config.js` file that exports an object, or a 'prettier' key in your `package.json` file.",
         "type": "boolean",
         "default": false,
         "order": 7

--- a/src/executePrettier/executePrettierOnBufferRange.js
+++ b/src/executePrettier/executePrettierOnBufferRange.js
@@ -8,6 +8,7 @@ const {
   getPrettierEslintOptions,
   shouldUseEslint,
   shouldUseStylelint,
+  shouldUseEditorConfig,
   runLinter,
 } = require('../atomInterface');
 const { getCurrentFilePath, isCurrentScopeStyleLintScope } = require('../editorInterface');
@@ -16,7 +17,9 @@ const handleError = require('./handleError');
 
 const getPrettierOptions = (editor: TextEditor) =>
   // $FlowFixMe
-  getPrettierInstance(editor).resolveConfig.sync(getCurrentFilePath(editor));
+  getPrettierInstance(editor).resolveConfig.sync(getCurrentFilePath(editor), {
+    editorconfig: shouldUseEditorConfig(),
+  });
 
 const executePrettier = (editor: TextEditor, text: string) =>
   // $FlowFixMe

--- a/src/executePrettier/executePrettierOnBufferRange.test.js
+++ b/src/executePrettier/executePrettierOnBufferRange.test.js
@@ -13,6 +13,7 @@ const {
   getPrettierEslintOptions,
   shouldUseEslint,
   shouldUseStylelint,
+  shouldUseEditorConfig,
   runLinter,
 } = require('../atomInterface');
 const { getCurrentFilePath, isCurrentScopeStyleLintScope } = require('../editorInterface');
@@ -35,6 +36,24 @@ beforeEach(() => {
   prettier.formatWithCursor.mockImplementation(() => formattedFixture);
   getPrettierInstance.mockImplementation(() => prettier);
   prettier.resolveConfig.sync.mockImplementation(() => optionsFixture);
+});
+
+it('uses editor config', async () => {
+  getCurrentFilePath.mockImplementation(() => 'foo.js');
+  shouldUseEditorConfig.mockImplementation(() => true);
+
+  await executePrettierOnBufferRange(editor, bufferRangeFixture);
+
+  expect(prettier.resolveConfig.sync).toHaveBeenCalledWith('foo.js', { editorconfig: true });
+});
+
+it('does not use editor config', async () => {
+  getCurrentFilePath.mockImplementation(() => 'foo.js');
+  shouldUseEditorConfig.mockImplementation(() => false);
+
+  await executePrettierOnBufferRange(editor, bufferRangeFixture);
+
+  expect(prettier.resolveConfig.sync).toHaveBeenCalledWith('foo.js', { editorconfig: false });
 });
 
 it('sets the transformed text in the buffer range', async () => {


### PR DESCRIPTION
Add an option to use configuration from `.editorconfig`, enabled by default.

BREAKING CHANGE: If the user has a `.editorconfig` file, with `max_line_length` then that value will
be used instead of Prettier's `printWidth`. This is the default behaviour of prettier when run on
the command line, but was not the default behaviour of prettier-atom (but it should be, and now is)

#514