### PR TITLE
fix: Use fork of prettier-eslint with cwd fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.6.3",
+    "@lewisl9029/prettier-eslint": "^9.0.1",
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^5.1.0",
     "atom-text-buffer-point": "^1.0.0",
@@ -32,7 +33,7 @@
     "lodash": "^4.17.13",
     "loophole": "^1.1.0",
     "prettier": "1.18.2",
-    "prettier-eslint": "^9.0.0",
+    "prettier-eslint": "npm:@lewisl9029/prettier-eslint",
     "prettier-stylelint": "^0.4.2",
     "read-pkg-up": "^6.0.0",
     "yarn-global-modules": "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,6 +897,25 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@lewisl9029/prettier-eslint@^9.0.1", "prettier-eslint@npm:@lewisl9029/prettier-eslint":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@lewisl9029/prettier-eslint/-/prettier-eslint-9.0.1.tgz#9be07525c3d917b8ff37477a94f2b4bdfca051d8"
+  integrity sha512-k4vh8RmH2VEvrBSBQ/jw8bvyh77LxnQi6GkGlU6P3X0fyVlqKoTcmA0WfUKPgAzoM3DO8f9iA+Fgr7laofz/dg==
+  dependencies:
+    "@typescript-eslint/parser" "^1.10.2"
+    common-tags "^1.4.0"
+    core-js "^3.1.4"
+    dlv "^1.1.0"
+    eslint "^5.0.0"
+    indent-string "^4.0.0"
+    lodash.merge "^4.6.0"
+    loglevel-colored-level-prefix "^1.0.0"
+    prettier "^1.7.0"
+    pretty-format "^23.0.1"
+    require-relative "^0.8.7"
+    typescript "^3.2.1"
+    vue-eslint-parser "^2.0.2"
+
 "@octokit/endpoint@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.5.0.tgz#d7e7960ffe39096cb67062f07efa84db52b20edb"


### PR DESCRIPTION
Using a temporary fork for prettier-eslint due to maintainer having been unresponsive. Feels
warranted as this is a showstopping bug affecting many users.

Fork uses the changes in this PR: https://github.com/prettier/prettier-eslint/pull/242

Implemented using yarn's alias feature: https://yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias

fix #505