### PR TITLE
fix(deps): correctly use new pkg-up, fixup 898ea715, #734

### DIFF
--- a/dist/formatOnSave/isPrettierInPackageJson.js
+++ b/dist/formatOnSave/isPrettierInPackageJson.js
@@ -12,9 +12,9 @@ const {
   shouldUseEslint
 } = require('../atomInterface');
 
-const hasPackageDependency = packageName => _.flow(_.get('package.dependencies'), _.has(packageName));
+const hasPackageDependency = packageName => _.flow(_.get('packageJson.dependencies'), _.has(packageName));
 
-const hasPackageDevDependency = packageName => _.flow(_.get('package.devDependencies'), _.has(packageName));
+const hasPackageDevDependency = packageName => _.flow(_.get('packageJson.devDependencies'), _.has(packageName));
 
 const hasPackage = packageName => _.overSome([hasPackageDependency(packageName), hasPackageDevDependency(packageName)]);
 

--- a/dist/formatOnSave/isPrettierInPackageJson.test.js
+++ b/dist/formatOnSave/isPrettierInPackageJson.test.js
@@ -29,7 +29,7 @@ describe('when shouldUseEslint is false', () => {
   });
   it('is true if prettier is a dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      "package": {
+      "packageJson": {
         dependencies: {
           prettier: '^0.0.1'
         }
@@ -40,7 +40,7 @@ describe('when shouldUseEslint is false', () => {
   });
   it('is true if prettier is a dev dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      "package": {
+      "packageJson": {
         devDependencies: {
           prettier: '^0.0.1'
         }
@@ -67,7 +67,7 @@ describe('when shouldUseEslint is true', () => {
   });
   it('is true if prettier-eslint is a dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      "package": {
+      "packageJson": {
         dependencies: {
           'prettier-eslint': '^0.0.1'
         }
@@ -78,7 +78,7 @@ describe('when shouldUseEslint is true', () => {
   });
   it('is true if prettier-eslint is a dev dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      "package": {
+      "packageJson": {
         devDependencies: {
           'prettier-eslint': '^0.0.1'
         }
@@ -89,7 +89,7 @@ describe('when shouldUseEslint is true', () => {
   });
   it('is true if prettier-eslint-cli is a dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      "package": {
+      "packageJson": {
         dependencies: {
           'prettier-eslint-cli': '^0.0.1'
         }
@@ -100,7 +100,7 @@ describe('when shouldUseEslint is true', () => {
   });
   it('is true if prettier-eslint-cli is a dev dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      "package": {
+      "packageJson": {
         devDependencies: {
           'prettier-eslint-cli': '^0.0.1'
         }
@@ -111,7 +111,7 @@ describe('when shouldUseEslint is true', () => {
   });
   it('is true if eslint-plugin-prettier is a dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      "package": {
+      "packageJson": {
         dependencies: {
           'eslint-plugin-prettier': '^0.0.1'
         }
@@ -122,7 +122,7 @@ describe('when shouldUseEslint is true', () => {
   });
   it('is true if eslint-plugin-prettier is a dev dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      "package": {
+      "packageJson": {
         devDependencies: {
           'eslint-plugin-prettier': '^0.0.1'
         }

--- a/src/formatOnSave/isPrettierInPackageJson.js
+++ b/src/formatOnSave/isPrettierInPackageJson.js
@@ -6,10 +6,10 @@ const { getCurrentDir } = require('../editorInterface');
 const { shouldUseEslint } = require('../atomInterface');
 
 const hasPackageDependency = (packageName: string): ((packageJson: {}) => boolean) =>
-  _.flow(_.get('package.dependencies'), _.has(packageName));
+  _.flow(_.get('packageJson.dependencies'), _.has(packageName));
 
 const hasPackageDevDependency = (packageName: string) =>
-  _.flow(_.get('package.devDependencies'), _.has(packageName));
+  _.flow(_.get('packageJson.devDependencies'), _.has(packageName));
 
 const hasPackage = (packageName: string): ((packageJson: {}) => boolean) =>
   _.overSome([hasPackageDependency(packageName), hasPackageDevDependency(packageName)]);

--- a/src/formatOnSave/isPrettierInPackageJson.test.js
+++ b/src/formatOnSave/isPrettierInPackageJson.test.js
@@ -21,7 +21,7 @@ describe('when shouldUseEslint is false', () => {
   });
 
   it('is true if prettier is a dependency', () => {
-    readPkgUp.sync.mockImplementation(() => ({ package: { dependencies: { prettier: '^0.0.1' } } }));
+    readPkgUp.sync.mockImplementation(() => ({ packageJson: { dependencies: { prettier: '^0.0.1' } } }));
 
     const actual = isPrettierInPackageJson();
 
@@ -29,7 +29,7 @@ describe('when shouldUseEslint is false', () => {
   });
 
   it('is true if prettier is a dev dependency', () => {
-    readPkgUp.sync.mockImplementation(() => ({ package: { devDependencies: { prettier: '^0.0.1' } } }));
+    readPkgUp.sync.mockImplementation(() => ({ packageJson: { devDependencies: { prettier: '^0.0.1' } } }));
 
     const actual = isPrettierInPackageJson();
 
@@ -58,7 +58,7 @@ describe('when shouldUseEslint is true', () => {
 
   it('is true if prettier-eslint is a dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      package: { dependencies: { 'prettier-eslint': '^0.0.1' } },
+      packageJson: { dependencies: { 'prettier-eslint': '^0.0.1' } },
     }));
 
     const actual = isPrettierInPackageJson();
@@ -68,7 +68,7 @@ describe('when shouldUseEslint is true', () => {
 
   it('is true if prettier-eslint is a dev dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      package: { devDependencies: { 'prettier-eslint': '^0.0.1' } },
+      packageJson: { devDependencies: { 'prettier-eslint': '^0.0.1' } },
     }));
 
     const actual = isPrettierInPackageJson();
@@ -78,7 +78,7 @@ describe('when shouldUseEslint is true', () => {
 
   it('is true if prettier-eslint-cli is a dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      package: { dependencies: { 'prettier-eslint-cli': '^0.0.1' } },
+      packageJson: { dependencies: { 'prettier-eslint-cli': '^0.0.1' } },
     }));
 
     const actual = isPrettierInPackageJson();
@@ -88,7 +88,7 @@ describe('when shouldUseEslint is true', () => {
 
   it('is true if prettier-eslint-cli is a dev dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      package: { devDependencies: { 'prettier-eslint-cli': '^0.0.1' } },
+      packageJson: { devDependencies: { 'prettier-eslint-cli': '^0.0.1' } },
     }));
 
     const actual = isPrettierInPackageJson();
@@ -98,7 +98,7 @@ describe('when shouldUseEslint is true', () => {
 
   it('is true if eslint-plugin-prettier is a dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      package: { dependencies: { 'eslint-plugin-prettier': '^0.0.1' } },
+      packageJson: { dependencies: { 'eslint-plugin-prettier': '^0.0.1' } },
     }));
 
     const actual = isPrettierInPackageJson();
@@ -108,7 +108,7 @@ describe('when shouldUseEslint is true', () => {
 
   it('is true if eslint-plugin-prettier is a dev dependency', () => {
     readPkgUp.sync.mockImplementation(() => ({
-      package: { devDependencies: { 'eslint-plugin-prettier': '^0.0.1' } },
+      packageJson: { devDependencies: { 'eslint-plugin-prettier': '^0.0.1' } },
     }));
 
     const actual = isPrettierInPackageJson();


### PR DESCRIPTION
A new issue just like #510. 

read-pkg-up in the new version renames a key from package to packageJson:

![image](https://user-images.githubusercontent.com/113721/80795615-a017cb00-8ba5-11ea-825d-ddfca3971f69.png)

<details>

Only format if Prettier in dependencies does not work.

Search terms: isDisabledIfNotInPackageJson #43 formatOnSave

</details>